### PR TITLE
WIP: Mod Source Compiler

### DIFF
--- a/Assets/Editor/AssetPack.cs
+++ b/Assets/Editor/AssetPack.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace ParkitectAssetEditor
 {
@@ -9,6 +11,22 @@ namespace ParkitectAssetEditor
     /// </summary>
     public class AssetPack
     {
+        /// <summary>
+        /// Gets or sets the path for Parkitect.
+        /// </summary>
+        /// <value>
+        /// The path for Parkitect.
+        /// </value>
+        public String ParkitectPath;
+
+        /// <summary>
+        /// List Of Enabled Project Assemblies
+        /// </summary>
+        /// <value>
+        /// The assemblies used for compiling the mod
+        /// </value>
+        public List<String> ProjectAssemblies { get; set; }
+
         /// <summary>
         /// Gets or sets the assets.
         /// </summary>
@@ -40,7 +58,7 @@ namespace ParkitectAssetEditor
         /// The archive setting. If true, assets should be archived with the mod to be uploaded to the workshop.
         /// </value>
         public bool ArchiveAssets { get; set; }
-        
+
         /// <summary>
         /// Adds the specified game object as an asset.
         /// </summary>
@@ -93,7 +111,7 @@ namespace ParkitectAssetEditor
 
             LayOutAssets();
         }
-        
+
         /// <summary>
         /// Removes the specified asset.
         /// </summary>

--- a/Assets/Editor/AssetPackModCompiler.cs
+++ b/Assets/Editor/AssetPackModCompiler.cs
@@ -1,0 +1,106 @@
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Microsoft.CSharp;
+using NUnit.Framework;
+using ParkitectAssetEditor.Utility;
+using UnityEditor;
+using UnityEngine;
+
+namespace ParkitectAssetEditor
+{
+    public static class AssetPackModCompiler
+    {
+        public static bool CompileModule(this AssetPack assetPack, String path)
+        {
+            String csprojFile = null;
+            foreach (var file in Directory.GetFiles(path))
+            {
+                if (file.Contains(".csproj"))
+                {
+                    csprojFile = Path.Combine(path, file);
+                    break;
+                }
+            }
+
+// update system path for mono
+#if UNITY_STANDALONE_OSX
+            var PATH = System.Environment.GetEnvironmentVariable("PATH");
+            var MonoPath = Path.Combine(EditorApplication.applicationContentsPath, "Frameworks/Mono/bin");
+            var value = PATH + ":" + MonoPath;
+            var target = System.EnvironmentVariableTarget.Process;
+            System.Environment.SetEnvironmentVariable("PATH", value, target);
+#elif UNITY_STANDALONE_WIN
+#else
+            var PATH = System.Environment.GetEnvironmentVariable("PATH");
+            var MonoPath = Path.Combine(EditorApplication.applicationContentsPath, "Mono/bin");
+            var value = PATH + ":" + MonoPath;
+            var target = System.EnvironmentVariableTarget.Process;
+            Environment.SetEnvironmentVariable("PATH", value, target);
+#endif
+
+            if (csprojFile == null) return false;
+
+            XmlDocument document = new XmlDocument();
+            document.Load(csprojFile);
+
+            var manager = new XmlNamespaceManager(document.NameTable);
+            manager.AddNamespace("x", ProjectDocument.DefaultCsProjNamespace);
+
+            // List the referenced assemblies of the mod.
+           List<String> assembleRefrencesInclude = document.SelectNodes("//x:Reference", manager)
+                .Cast<XmlNode>()
+                .Select(node => node.Attributes["Include"])
+                .Select(name => name.Value.Split(',').FirstOrDefault()).ToList();
+
+
+           List<String> unresolvedSourceFiles = document.SelectNodes("//x:Compile", manager)
+               .Cast<XmlNode>()
+               .Select(node => node.Attributes["Include"].Value).ToList();
+
+           var assemblyFiles = new List<string>();
+           var sourceFiles = new List<string>();
+           foreach (var inc in assembleRefrencesInclude)
+           {
+               if (Utility.Utility.SystemAssemblies.Contains(inc))
+               {
+                   Debug.Log("Resolved Assembly Reference:" + inc + ".dll");
+                   assemblyFiles.Add(inc + ".dll");
+               }
+               else
+               {
+                   var pt = Path.Combine(Path.Combine(assetPack.ParkitectPath, "Parkitect_Data/Managed/"),
+                       inc + ".dll");
+                   Debug.Log("Resolved Assembly Reference:" + pt);
+                   assemblyFiles.Add(pt);
+               }
+           }
+
+           sourceFiles.AddRange(unresolvedSourceFiles.Select(file => Path.Combine(path, file)));
+
+           Debug.Log("Compile using compiler version v4.0");
+           var csCodeProvider =
+               new CSharpCodeProvider(new Dictionary<string, string>
+               {
+                   // {"CompilerVersion", "v4.0"}
+               });
+
+           var parameters = new CompilerParameters(assemblyFiles.ToArray(), Path.Combine(ProjectManager.Project.Value.ModDirectory,"build.dll"));
+            var result = csCodeProvider.CompileAssemblyFromFile(parameters, sourceFiles.ToArray());
+
+            foreach (var o in result.Output)
+            {
+                Debug.Log(o);
+            }
+            foreach (var error in result.Errors.Cast<CompilerError>())
+            {
+                Debug.LogError(error.ErrorNumber + ":" + error.Line + ":" + error.Column + ":" + error.ErrorText + " in " + error.FileName);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Assets/Editor/AssetPackModCompiler.cs
+++ b/Assets/Editor/AssetPackModCompiler.cs
@@ -52,54 +52,52 @@ namespace ParkitectAssetEditor
             manager.AddNamespace("x", ProjectDocument.DefaultCsProjNamespace);
 
             // List the referenced assemblies of the mod.
-           List<String> assembleRefrencesInclude = document.SelectNodes("//x:Reference", manager)
+            List<String> assembleRefrencesInclude = document.SelectNodes("//x:Reference", manager)
                 .Cast<XmlNode>()
                 .Select(node => node.Attributes["Include"])
                 .Select(name => name.Value.Split(',').FirstOrDefault()).ToList();
 
 
-           List<String> unresolvedSourceFiles = document.SelectNodes("//x:Compile", manager)
-               .Cast<XmlNode>()
-               .Select(node => node.Attributes["Include"].Value).ToList();
+            List<String> unresolvedSourceFiles = document.SelectNodes("//x:Compile", manager)
+                .Cast<XmlNode>()
+                .Select(node => node.Attributes["Include"].Value).ToList();
 
-           var assemblyFiles = new List<string>();
-           var sourceFiles = new List<string>();
-           foreach (var inc in assembleRefrencesInclude)
-           {
-               if (Utility.Utility.SystemAssemblies.Contains(inc))
-               {
-                   Debug.Log("Resolved Assembly Reference:" + inc + ".dll");
-                   assemblyFiles.Add(inc + ".dll");
-               }
-               else
-               {
-                   var pt = Path.Combine(Path.Combine(assetPack.ParkitectPath, "Parkitect_Data/Managed/"),
-                       inc + ".dll");
-                   Debug.Log("Resolved Assembly Reference:" + pt);
-                   assemblyFiles.Add(pt);
-               }
-           }
+            var assemblyFiles = new List<string>();
+            var sourceFiles = new List<string>();
+            foreach (var inc in assembleRefrencesInclude)
+            {
+                if (Utility.Utility.SystemAssemblies.Contains(inc))
+                {
+                    Debug.Log("Resolved Assembly Reference:" + inc + ".dll");
+                    assemblyFiles.Add(inc + ".dll");
+                }
+                else
+                {
+                    var pt = Path.Combine(Path.Combine(assetPack.ParkitectPath, "Parkitect_Data/Managed/"),
+                        inc + ".dll");
+                    Debug.Log("Resolved Assembly Reference:" + pt);
+                    assemblyFiles.Add(pt);
+                }
+            }
 
-           sourceFiles.AddRange(unresolvedSourceFiles.Select(file => Path.Combine(path, file)));
+            sourceFiles.AddRange(unresolvedSourceFiles.Select(file => Path.Combine(path, file)));
 
-           Debug.Log("Compile using compiler version v4.0");
-           var csCodeProvider = new CSharpCodeProvider();
-           CompilerParameters parameters = new CompilerParameters(assemblyFiles.ToArray())
-           {
-               GenerateExecutable = false,
-               OutputAssembly = Path.Combine(ProjectManager.Project.Value.ModDirectory, "build.dll")
-           };
+            Debug.Log("Compile using compiler version v4.0");
+            var csCodeProvider = new CSharpCodeProvider();
 
-           // var parameters = new CompilerParameters(assemblyFiles.ToArray(), Path.Combine(ProjectManager.Project.Value.ModDirectory,"build.dll"));
+            var parameters = new CompilerParameters(assemblyFiles.ToArray(),
+                Path.Combine(ProjectManager.Project.Value.ModDirectory, "build.dll"));
             var result = csCodeProvider.CompileAssemblyFromFile(parameters, sourceFiles.ToArray());
 
             foreach (var o in result.Output)
             {
                 Debug.Log(o);
             }
+
             foreach (var error in result.Errors.Cast<CompilerError>())
             {
-                Debug.LogError(error.ErrorNumber + ":" + error.Line + ":" + error.Column + ":" + error.ErrorText + " in " + error.FileName);
+                Debug.LogError(error.ErrorNumber + ":" + error.Line + ":" + error.Column + ":" + error.ErrorText +
+                               " in " + error.FileName);
             }
 
             return true;

--- a/Assets/Editor/AssetPackModCompiler.cs
+++ b/Assets/Editor/AssetPackModCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -82,13 +83,14 @@ namespace ParkitectAssetEditor
            sourceFiles.AddRange(unresolvedSourceFiles.Select(file => Path.Combine(path, file)));
 
            Debug.Log("Compile using compiler version v4.0");
-           var csCodeProvider =
-               new CSharpCodeProvider(new Dictionary<string, string>
-               {
-                   // {"CompilerVersion", "v4.0"}
-               });
+           var csCodeProvider = new CSharpCodeProvider();
+           CompilerParameters parameters = new CompilerParameters(assemblyFiles.ToArray())
+           {
+               GenerateExecutable = false,
+               OutputAssembly = Path.Combine(ProjectManager.Project.Value.ModDirectory, "build.dll")
+           };
 
-           var parameters = new CompilerParameters(assemblyFiles.ToArray(), Path.Combine(ProjectManager.Project.Value.ModDirectory,"build.dll"));
+           // var parameters = new CompilerParameters(assemblyFiles.ToArray(), Path.Combine(ProjectManager.Project.Value.ModDirectory,"build.dll"));
             var result = csCodeProvider.CompileAssemblyFromFile(parameters, sourceFiles.ToArray());
 
             foreach (var o in result.Output)

--- a/Assets/Editor/AssetPackModCompiler.cs.meta
+++ b/Assets/Editor/AssetPackModCompiler.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7c6c8bb7f8a34620ba954f0a0745b2bd
+timeCreated: 1589488133

--- a/Assets/Editor/ProjectManager.cs
+++ b/Assets/Editor/ProjectManager.cs
@@ -89,9 +89,9 @@ namespace ParkitectAssetEditor
             }
 
             XmlDocument csProj = new XmlDocument();
-            csProj.LoadXml(ProjectDocument.CSProj.Replace("${RootNamespace}", "Parkitect")
-                .Replace("${AssemblyName}","Parkitect")
-                .Replace("${OutputPath}", "./debug"));
+            csProj.LoadXml(ProjectDocument.CSProj.Replace("${RootNamespace}", "ParkitectMod")
+                .Replace("${AssemblyName}","ParkitectMod")
+                .Replace("${OutputPath}", ProjectManager.Project.Value.ModDirectory));
 
             var manager = new XmlNamespaceManager(csProj.NameTable);
             manager.AddNamespace("x", ProjectDocument.DefaultCsProjNamespace);
@@ -138,8 +138,6 @@ namespace ParkitectAssetEditor
 
                 }
             }
-
-
 
             csProj.Save(Path.Combine(projectPath,"ParkitectMod.csproj"));
 

--- a/Assets/Editor/ProjectManager.cs
+++ b/Assets/Editor/ProjectManager.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.CSharp;
 using Newtonsoft.Json;
 using ParkitectAssetEditor.Compression;
 using ParkitectAssetEditor.UI;
@@ -12,7 +16,6 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-
 namespace ParkitectAssetEditor
 {
     /// <summary>
@@ -48,7 +51,7 @@ namespace ParkitectAssetEditor
         }
 
         private static string _autoSaveHash = "";
-        
+
         /// <summary>
         /// Saves the project.
         /// </summary>
@@ -65,12 +68,80 @@ namespace ParkitectAssetEditor
                 Debug.Log("There are no defined assets in the Asset Pack, can't save");
                 return false;
             }
-            
+
             string output = JsonConvert.SerializeObject(AssetPack);
 
             File.WriteAllText(path, output);
 
             Debug.Log(string.Format("Finished saving project {0}", path));
+
+            return true;
+        }
+
+        public static bool UpdateProjectSetup()
+        {
+
+            String projectPath = Path.Combine(Application.dataPath.Replace("/Assets", ""),"ParkitectMod");
+
+            if (!Directory.Exists(projectPath)) {
+                Directory.CreateDirectory(projectPath);
+                File.WriteAllText(Path.Combine(projectPath, "Main.cs"), ProjectDocument.MainCS);
+            }
+
+            XmlDocument csProj = new XmlDocument();
+            csProj.LoadXml(ProjectDocument.CSProj.Replace("${RootNamespace}", "Parkitect")
+                .Replace("${AssemblyName}","Parkitect")
+                .Replace("${OutputPath}", "./debug"));
+
+            var manager = new XmlNamespaceManager(csProj.NameTable);
+            manager.AddNamespace("x", ProjectDocument.DefaultCsProjNamespace);
+
+            var project = csProj.SelectNodes("//x:Project", manager).Cast<XmlNode>().First();
+
+            XmlElement itemGroup = csProj.CreateElement("ItemGroup",ProjectDocument.DefaultCsProjNamespace);
+            project.AppendChild(itemGroup);
+
+            foreach (var assmb in AssetPack.ProjectAssemblies)
+            {
+                XmlElement reff = csProj.CreateElement("Reference",ProjectDocument.DefaultCsProjNamespace);
+                var refrenceAttribute = csProj.CreateAttribute("Include");
+                refrenceAttribute.InnerText = assmb;
+                reff.Attributes.Append(refrenceAttribute);
+
+                var prv = csProj.CreateElement("Private",ProjectDocument.DefaultCsProjNamespace);
+                prv.InnerText = "False";
+                reff.AppendChild(prv);
+                if (!string.IsNullOrEmpty(AssetPack.ParkitectPath))
+                {
+                    var hint = csProj.CreateElement("HintPath",ProjectDocument.DefaultCsProjNamespace);
+                    hint.InnerText = Path.Combine(Path.Combine(AssetPack.ParkitectPath, "Parkitect_Data/Managed/"), assmb + ".dll");
+                    reff.AppendChild(hint);
+                }
+
+                itemGroup.AppendChild(reff);
+            }
+
+            XmlElement sourceGroup = csProj.CreateElement("ItemGroup",ProjectDocument.DefaultCsProjNamespace);
+            project.AppendChild(sourceGroup);
+
+            foreach (var ff in Directory.GetFiles(projectPath,"*.*", SearchOption.AllDirectories))
+            {
+                if (ff.EndsWith(".cs"))
+                {
+                    String fil = ff.Substring(projectPath.Length + 1);
+                    XmlElement comp = csProj.CreateElement("Compile",ProjectDocument.DefaultCsProjNamespace);
+                    var refrenceAttribute = csProj.CreateAttribute("Include");
+                    refrenceAttribute.InnerText = fil;
+                    comp.Attributes.Append(refrenceAttribute);
+
+                    sourceGroup.AppendChild(comp);
+
+                }
+            }
+
+
+
+            csProj.Save(Path.Combine(projectPath,"ParkitectMod.csproj"));
 
             return true;
         }
@@ -85,8 +156,14 @@ namespace ParkitectAssetEditor
 
             var path = Path.Combine(Project.Value.ProjectDirectory, Project.Value.ProjectFile);
 
+            String projectPath = Path.Combine(Application.dataPath.Replace("/Assets", ""),"ParkitectMod");
             if (Save() && AssetPack.CreateAssetBundle())
             {
+                if (Directory.Exists(projectPath))
+                {
+                    AssetPack.CompileModule(projectPath);
+                }
+
                 File.Copy(path, Path.Combine(Project.Value.ModDirectory, Project.Value.ProjectFile), true);
 
                 var assetZipPath = Path.Combine(Project.Value.ModDirectory, "assets.zip");
@@ -96,7 +173,7 @@ namespace ParkitectAssetEditor
                 {
                     File.Delete(assetZipPath);
                 }
-                
+
                 if (exportAssetZip)
                 {
                     Debug.Log(string.Format("Archiving {0} to {1}", Project.Value.ProjectDirectory, assetZipPath));
@@ -111,7 +188,7 @@ namespace ParkitectAssetEditor
             }
 
             Debug.LogWarning(string.Format("Failed saving project {0}", path));
-            
+
             return false;
         }
 
@@ -136,9 +213,9 @@ namespace ParkitectAssetEditor
                 ProjectFile = Path.GetFileName(path),
                 ProjectFileAutoSave = Path.GetFileName(path) + ".autosave"
             };
-            
+
             AssetPack = JsonConvert.DeserializeObject<AssetPack>(File.ReadAllText(path));
-            
+
             AssetPack.LoadGameObjects();
             AssetPack.InitAssetsInScene();
 
@@ -159,7 +236,7 @@ namespace ParkitectAssetEditor
         public static void AutoSave()
         {
             var path = EditorPrefs.GetString("loadedProject");
-            
+
             string output = JsonConvert.SerializeObject(AssetPack);
 
             using (var md5 = MD5.Create())
@@ -189,7 +266,7 @@ namespace ParkitectAssetEditor
         public static void AutoLoad()
         {
             var path = EditorPrefs.GetString("loadedProject");
-            
+
             // .autosave = 9 characters, them hacks!
             var pathWithoutAutoSave = path.Remove(path.Length - 9);
 
@@ -203,7 +280,7 @@ namespace ParkitectAssetEditor
                 ProjectFile = Path.GetFileName(pathWithoutAutoSave),
                 ProjectFileAutoSave = Path.GetFileName(pathWithoutAutoSave) + ".autosave"
             };
-            
+
             AssetPack = JsonConvert.DeserializeObject<AssetPack>(File.ReadAllText(path));
 
             EditorPrefs.SetString("loadedProject", Path.Combine(Project.Value.ProjectDirectory, Project.Value.ProjectFileAutoSave));
@@ -246,7 +323,7 @@ namespace ParkitectAssetEditor
             {
                 throw new ProjectAlreadyExistsException(string.Format("There already is a project at {0}", projectFilePath));
             }
-            
+
             if (Directory.Exists(modDirectory))
             {
                 throw new ProjectAlreadyExistsException(string.Format("Your Parkitect installation already has a mod called {0} at {1}", name, modDirectory));

--- a/Assets/Editor/UI/AssetEditorWindow.cs
+++ b/Assets/Editor/UI/AssetEditorWindow.cs
@@ -299,8 +299,7 @@ namespace ParkitectAssetEditor.UI
 
             if (GUILayout.Button("Parkitect Path"))
             {
-                string path = EditorUtility.OpenFolderPanel("Parkitect Path", "", "");
-                Debug.Log("Parkitect path:"+ path);
+                ProjectManager.AssetPack.ParkitectPath = EditorUtility.OpenFolderPanel("Parkitect Path", "", "");
             }
 		}
 

--- a/Assets/Editor/Utility/ProjectDocument.cs
+++ b/Assets/Editor/Utility/ProjectDocument.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace ParkitectAssetEditor.Utility
+{
+    public static class ProjectDocument
+    {
+        public static String DefaultCsProjNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+        public static String MainCS
+        {
+            get
+            {
+                return @"namespace ParkitectMod
+{
+
+    public class Main : IMod
+    {
+
+        public void onEnabled()
+        {
+        }
+
+        public void onDisabled()
+        {
+        }
+
+        public string Name => "" "";
+
+            public string Description => "" "";
+
+        string IMod.Identifier => "" "";
+
+    }
+}";
+            }
+        }
+
+        public static string CSProj
+        {
+            get
+            {
+                return @"<?xml version=""1.0"" encoding=""utf-8""?>
+            <Project ToolsVersion=""12.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
+                <PropertyGroup>
+                    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+                    <Platform Condition="" '$(Platform)' == '' "">AnyCPU</Platform>
+                    <ProjectGuid>{62921F50-6388-43FE-9DB2-B7F8556A7931}</ProjectGuid>
+                    <OutputType>Library</OutputType>
+                    <AppDesignerFolder>Properties</AppDesignerFolder>
+                    <RootNamespace>${RootNamespace}</RootNamespace>
+                    <AssemblyName>${AssemblyName}</AssemblyName>
+                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                    <FileAlignment>512</FileAlignment>
+                </PropertyGroup>
+                <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+                    <PlatformTarget>AnyCPU</PlatformTarget>
+                    <DebugSymbols>true</DebugSymbols>
+                    <DebugType>full</DebugType>
+                    <Optimize>false</Optimize>
+                    <OutputPath>${OutputPath}</OutputPath>
+                    <DefineConstants>DEBUG;TRACE</DefineConstants>
+                    <ErrorReport>prompt</ErrorReport>
+                    <WarningLevel>4</WarningLevel>
+                    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                </PropertyGroup>
+                <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+                    <PlatformTarget>AnyCPU</PlatformTarget>
+                    <DebugType>pdbonly</DebugType>
+                    <Optimize>true</Optimize>
+                    <OutputPath>${OutputPath}</OutputPath>
+                    <DefineConstants>TRACE</DefineConstants>
+                    <ErrorReport>prompt</ErrorReport>
+                    <WarningLevel>4</WarningLevel>
+                    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                </PropertyGroup>
+                <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+            </Project>";
+            }
+        }
+    }
+}

--- a/Assets/Editor/Utility/ProjectDocument.cs.meta
+++ b/Assets/Editor/Utility/ProjectDocument.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bf31bb975ff84d9b99f7efb1f15f15fc
+timeCreated: 1589502578

--- a/Assets/Editor/Utility/Utility.cs
+++ b/Assets/Editor/Utility/Utility.cs
@@ -27,7 +27,167 @@ namespace ParkitectAssetEditor.Utility {
             }
         }
 
-        
+           /// <summary>
+        /// Gets the path to the game path.
+        /// </summary>
+        public static string GamePath
+        {
+            get
+            {
+#if UNITY_STANDALONE_OSX
+				return System.IO.Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "/../Library/Application Support/Parkitect/");
+#elif UNITY_STANDALONE_WIN
+				return System.IO.Path.GetFullPath(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/Parkitect/", "Mods"));
+#else
+                return System.IO.Path.GetFullPath("~/Steam/steamapps/common/Parkitect/");
+#endif
+            }
+        }
+
+        public  static readonly string[] DefaultAssemblies =
+        {
+            "System", "System.Core", "System.Data", "Parkitect", "System.Data", "System.Xml",
+        };
+
+        public static readonly string[] SystemAssemblies = {
+            "System.ComponentModel.DataAnnotations",
+            "System.Configuration",
+            "System.Configuration.Install",
+            "System.Core",
+            "System.Data",
+            "System.Design",
+            "System.DirectoryServices",
+            "System",
+            "System.Drawing",
+            "System.EnterpriseServices",
+            "System.IdentityModel",
+            "System.IdentityModel.Selectors",
+            "System.Messaging",
+            "System.Numerics",
+            "System.Runtime.Serialization",
+            "System.Runtime.Serialization.Formatters.Soap",
+            "System.Security",
+            "System.ServiceModel.Activation",
+            "System.ServiceModel",
+            "System.ServiceModel.Internals",
+            "System.Transactions",
+            "System.Web.ApplicationServices",
+            "System.Web",
+            "System.Web.Services",
+            "System.Windows.Forms",
+            "System.Xml",
+        };
+
+        public static readonly string[] ParkitectAssemblies =
+        {
+            "Accessibility",
+            "DOTween43",
+            "DOTween46",
+            "DOTween50",
+            "DOTween",
+            "ICSharpCode.SharpZipLib",
+            "Mono.Data.Sqlite",
+            "Mono.Data.Tds",
+            "Mono.Messaging",
+            "Mono.Posix",
+            "Mono.Security",
+            "Mono.WebBrowser",
+            "mscorlib",
+            "Novell.Directory.Ldap",
+            "Parkitect",
+            "protobuf-net",
+            "System.ComponentModel.DataAnnotations",
+            "System.Configuration",
+            "System.Configuration.Install",
+            "System.Core",
+            "System.Data",
+            "System.Design",
+            "System.DirectoryServices",
+            "System",
+            "System.Drawing",
+            "System.EnterpriseServices",
+            "System.IdentityModel",
+            "System.IdentityModel.Selectors",
+            "System.Messaging",
+            "System.Numerics",
+            "System.Runtime.Serialization",
+            "System.Runtime.Serialization.Formatters.Soap",
+            "System.Security",
+            "System.ServiceModel.Activation",
+            "System.ServiceModel",
+            "System.ServiceModel.Internals",
+            "System.Transactions",
+            "System.Web.ApplicationServices",
+            "System.Web",
+            "System.Web.Services",
+            "System.Windows.Forms",
+            "System.Xml",
+            "ThirdParty.",
+            "ThirdParty",
+            "ThirdParty.DynamicDecals",
+            "ThirdParty.GraphMaker",
+            "ThirdParty.Lutify",
+            "ThirdParty.ScreenSpaceCloudShadow",
+            "ThirdParty.TiltShift",
+            "ThirdParty.UnityUiExtensions",
+            "UnityEngine.AccessibilityModule",
+            "UnityEngine.AIModule",
+            "UnityEngine.Analytics",
+            "UnityEngine.AnimationModule",
+            "UnityEngine.ARModule",
+            "UnityEngine.AssetBundleModule",
+            "UnityEngine.AudioModule",
+            "UnityEngine.ClothModule",
+            "UnityEngine.ClusterInputModule",
+            "UnityEngine.ClusterRendererModule",
+            "UnityEngine.CoreModule",
+            "UnityEngine.CrashLog",
+            "UnityEngine.CrashReportingModule",
+            "UnityEngine.DirectorModule",
+            "UnityEngine",
+            "UnityEngine.GameCenterModule",
+            "UnityEngine.GridModule",
+            "UnityEngine.ImageConversionModule",
+            "UnityEngine.IMGUIModule",
+            "UnityEngine.InputModule",
+            "UnityEngine.JSONSerializeModule",
+            "UnityEngine.Networking",
+            "UnityEngine.ParticlesLegacyModule",
+            "UnityEngine.ParticleSystemModule",
+            "UnityEngine.PerformanceReportingModule",
+            "UnityEngine.Physics2DModule",
+            "UnityEngine.PhysicsModule",
+            "UnityEngine.ScreenCaptureModule",
+            "UnityEngine.SharedInternalsModule",
+            "UnityEngine.SpatialTracking",
+            "UnityEngine.SpriteMaskModule",
+            "UnityEngine.SpriteShapeModule",
+            "UnityEngine.StandardEvents",
+            "UnityEngine.StyleSheetsModule",
+            "UnityEngine.TerrainModule",
+            "UnityEngine.TerrainPhysicsModule",
+            "UnityEngine.TextRenderingModule",
+            "UnityEngine.TilemapModule",
+            "UnityEngine.Timeline",
+            "UnityEngine.UI",
+            "UnityEngine.UIElementsModule",
+            "UnityEngine.UIModule",
+            "UnityEngine.UNETModule",
+            "UnityEngine.UnityAnalyticsModule",
+            "UnityEngine.UnityConnectModule",
+            "UnityEngine.UnityWebRequestAudioModule",
+            "UnityEngine.UnityWebRequestModule",
+            "UnityEngine.UnityWebRequestTextureModule",
+            "UnityEngine.UnityWebRequestWWWModule",
+            "UnityEngine.VehiclesModule",
+            "UnityEngine.VideoModule",
+            "UnityEngine.VRModule",
+            "UnityEngine.WebModule",
+            "UnityEngine.WindModule",
+            "UnityFbxPrefab",
+            "Unity.Postprocessing.Runtime"
+        };
+
 		private static Mesh npcMesh;
 		private static Material sceneViewMaterial;
 
@@ -49,7 +209,7 @@ namespace ParkitectAssetEditor.Utility {
 			foreach (var seat in seats)
 			{
 				sceneViewMaterial.SetPass(0);
-				Graphics.DrawMeshNow(npcMesh, seat.position, seat.rotation); 
+				Graphics.DrawMeshNow(npcMesh, seat.position, seat.rotation);
 				sceneViewMaterial.SetPass(1);
 				Graphics.DrawMeshNow(npcMesh, seat.position, seat.rotation);
 			}


### PR DESCRIPTION
This is a basic wip to add code support to parkitect mods. I'm a little stuck with the compiling part of the setup where I get this error when it tries to build the assembly:
```
Unhandled Exception: System.TypeLoadException: Could not load type 'System.Runtime.CompilerServices.ExtensionAttribute' from assembly 'Parkitect'.
UnityEngine.Debug:Log(Object)
```
There are some functionality issues that need to be cleaned up for this to work effectively. not entirly sure how this should be arranged in terms of such a tool. The other thing I would like to do and haven't quite worked out is added the mod working directory to the root sln project or atleast have a button that would open up a solution but that might not be workable in the unity toolset. the other thing would be to test this on other platforms and see if it is capable of compiling on those other platforms. 

I'm just not entirely sure how this should be put together or work. This is more of a proof of concept then anything. still more convient to have the tool generate the workspace for the mod to use then manually setting up the csproj to point to all the assemblies. it should also help with packaging the code along with the assets.  