### PR TITLE
Initial setup ease, bug fixes and migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /[Bb]uilds/
 /Assets/AssetStoreTools*
 /Assets/Resources/AssetPack/
+/Assets/Resources/AssetPack.meta
 
 # Visual Studio 2015 cache directory
 /.vs/
@@ -36,4 +37,3 @@ sysinfo.txt
 
 *.assetProject*
 *.autosave*
-

--- a/Assets/Editor/AssetPackSerializer.cs
+++ b/Assets/Editor/AssetPackSerializer.cs
@@ -76,6 +76,7 @@ namespace ParkitectAssetEditor
             var path = string.Format("Assets/Resources/AssetPack/{0}.prefab", Guid);
 
             PrefabUtility.SaveAsPrefabAsset(gameObject, path);
+
             return path;
         }
         

--- a/Assets/Editor/AssetPackSerializer.cs
+++ b/Assets/Editor/AssetPackSerializer.cs
@@ -75,8 +75,7 @@ namespace ParkitectAssetEditor
 
             var path = string.Format("Assets/Resources/AssetPack/{0}.prefab", Guid);
 
-            PrefabUtility.CreatePrefab(path, gameObject);
-
+            PrefabUtility.SaveAsPrefabAsset(gameObject, path);
             return path;
         }
         

--- a/Assets/Editor/UI/AssetEditorWindow.cs
+++ b/Assets/Editor/UI/AssetEditorWindow.cs
@@ -277,7 +277,9 @@ namespace ParkitectAssetEditor.UI
 			if (GUILayout.Button("Export Asset Pack"))
 			{
 				if (ProjectManager.Export(ProjectManager.AssetPack.ArchiveAssets))
+				{
 					GUIUtility.ExitGUI();
+				}
 			}
 		}
 

--- a/Assets/Editor/UI/AssetEditorWindow.cs
+++ b/Assets/Editor/UI/AssetEditorWindow.cs
@@ -276,7 +276,8 @@ namespace ParkitectAssetEditor.UI
 
 			if (GUILayout.Button("Export Asset Pack"))
 			{
-				ProjectManager.Export(ProjectManager.AssetPack.ArchiveAssets);
+				if (ProjectManager.Export(ProjectManager.AssetPack.ArchiveAssets))
+					GUIUtility.ExitGUI();
 			}
 		}
 

--- a/Assets/Editor/UI/AssetEditorWindow.cs
+++ b/Assets/Editor/UI/AssetEditorWindow.cs
@@ -188,9 +188,9 @@ namespace ParkitectAssetEditor.UI
 		{
 			// Remove delegate listener if it has previously
 			// been assigned.
-			SceneView.onSceneGUIDelegate -= OnSceneGUI;
+			SceneView.duringSceneGui -= OnSceneGUI;
 			// Add (or re-add) the delegate.
-			SceneView.onSceneGUIDelegate += OnSceneGUI;
+			SceneView.duringSceneGui += OnSceneGUI;
 		}
 
 		void OnDestroy()
@@ -198,7 +198,7 @@ namespace ParkitectAssetEditor.UI
 			// When the window is destroyed, remove the delegate
 			// so that it will no longer do any drawing.
 			//Exporter.SaveToXML(ModManager);
-			SceneView.onSceneGUIDelegate -= OnSceneGUI;
+			SceneView.duringSceneGui -= OnSceneGUI;
 
 		}
 

--- a/Assets/Editor/UI/AutoSave.cs
+++ b/Assets/Editor/UI/AutoSave.cs
@@ -6,11 +6,12 @@ using UnityEditor;
 
 namespace ParkitectAssetEditor.Assets.Editor.UI
 {
-    public class AssetProcessor : SaveAssetsProcessor
+    public class AssetProcessor : UnityEditor.AssetModificationProcessor
     {
         static string[] OnWillSaveAssets(string[] paths)
         {
-            ProjectManager.Save();
+            if (ProjectManager.Project != null)
+                ProjectManager.Save();
 
             return paths;
         }

--- a/Assets/Resources/AssetPack.meta
+++ b/Assets/Resources/AssetPack.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: e0b6a9b2249b9b6498f614c0d3b4c532
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
I've attempted to fix some of the things that bug me, especially in new setups and fix all of the warnings and errors I've stumbled across so far. Therefore, this PR is handling a multiple files and is a bit oddly spread out around commits. Summary of what it does and what each commit contains:

## c7965de
The `Resources/AssetPack` folder was gitignored, the corresponding `.meta` file, however, was not. This leads Unity to immediately deleting the meta file upon the first start, along with a warning. After exporting, it will be re-created, but possibly with a different GUID, which can lead to history noise.
  **Important:** Although I do not believe that the meta file is really used for anything, this commit will delete the file in order to properly add it to the gitignore for good. Unity will simply re-create it (as it had done before), so no harm should be done.

## 4804ebc
Fixes the following exception that is usually thrown on new projects whenever `ProjectManager.Project` was not assigned (i.e. any time Unity saved assets before _Create Project_ was clicked):

```
InvalidOperationException: Nullable object must have a value.
System.Nullable`1[T].get_Value () (at <fb001e01371b4adca20013e0ac763896>:0)
ParkitectAssetEditor.ProjectManager.Save () (at Assets/Editor/ProjectManager.cs:57)
ParkitectAssetEditor.Assets.Editor.UI.AssetProcessor.OnWillSaveAssets (System.String[] paths) (at Assets/Editor/UI/AutoSave.cs:13)
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <fb001e01371b4adca20013e0ac763896>:0)
Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <fb001e01371b4adca20013e0ac763896>:0)
System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <fb001e01371b4adca20013e0ac763896>:0)
UnityEditor.AssetModificationProcessorInternal.OnWillSaveAssets (System.String[] assets, System.String[]& assetsThatShouldBeSaved, System.String[]& assetsThatShouldBeReverted, System.Boolean explicitlySaveAsset) (at <fd8fd784002f49beab0500d3a24213b9>:0)
```

Additionally, replaced the base class to avoid Unity logging a warning about using a deprecated class.

## f96be63
Fixes deprecation warnings for `onSceneGUIDelegate` that Unity logs as warnings on each save.

## a6e3a84
Fixed the following error that occurred during the build:
```
EndLayoutGroup: BeginLayoutGroup must be called first.
UnityEngine.GUILayout:EndVertical()
ParkitectAssetEditor.UI.AssetEditorWindow:OnGUI() (at Assets/Editor/UI/AssetEditorWindow.cs:164)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
```

(... for which the fix is apparently to just tell the GUI that nothing is going to happen from here on).

## f8b6236 
Fixed some minor code style issues that happened because habits. In particular, restored previously erroneously removed empty lines and added brackets around single-statement conditionals.