### PR TITLE
Unify formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,128 @@
+# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+[*.cs]
+
+
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = spaces
+
+[*.foobar]
+#Formatting - indentation options
+
+#indent switch case contents.
+csharp_indent_case_contents = true
+#indent switch labels
+csharp_indent_switch_labels = true
+
+#Formatting - new line options
+
+#place catch statements on a new line
+csharp_new_line_before_catch = true
+#place else statements on a new line
+csharp_new_line_before_else = true
+#require members of object intializers to be on separate lines
+csharp_new_line_before_members_in_object_initializers = true
+#require braces to be on a new line for control_blocks, lambdas, methods, properties, object_collection_array_initializers, accessors, and types (also known as "Allman" style)
+csharp_new_line_before_open_brace = control_blocks, lambdas, methods, properties, object_collection_array_initializers, accessors, types
+
+#Formatting - organize using options
+
+#sort System.* using directives alphabetically, and place them before other usings
+dotnet_sort_system_directives_first = true
+
+#Formatting - spacing options
+
+#require NO space between a cast and the value
+csharp_space_after_cast = false
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on separate lines
+csharp_preserve_single_line_blocks = false
+#leave statements and member declarations on the same line
+csharp_preserve_single_line_statements = true
+
+#Style - Code block preferences
+
+#prefer no curly braces if allowed
+csharp_prefer_braces = false:suggestion
+
+#Style - expression bodied member options
+
+#prefer block bodies for accessors
+csharp_style_expression_bodied_accessors = false:suggestion
+#prefer block bodies for constructors
+csharp_style_expression_bodied_constructors = false:suggestion
+#prefer block bodies for methods
+csharp_style_expression_bodied_methods = false:suggestion
+#prefer block bodies for properties
+csharp_style_expression_bodied_properties = false:suggestion
+
+#Style - expression level options
+
+#prefer out variables to be declared before the method call
+csharp_style_inlined_variable_declaration = false:suggestion
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - Expression-level  preferences
+
+#prefer objects to be initialized using object initializers when possible
+dotnet_style_object_initializer = true:suggestion
+
+#Style - implicit and explicit types
+
+#prefer explicit type over var in all cases, unless overridden by another code style rule
+csharp_style_var_elsewhere = false:suggestion
+#prefer explicit type over var to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = false:suggestion
+#prefer var when the type is already mentioned on the right-hand side of a declaration expression
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - modifier options
+
+#prefer accessibility modifiers to be declared except for public interface members. This will currently not differ from always and will act as future proofing for if C# adds default interface methods.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+#Style - Modifier preferences
+
+#when this rule is set to a list of modifiers, prefer the specified ordering.
+csharp_preferred_modifier_order = public,internal,private,protected,static,override,readonly,virtual,sealed,abstract,new:suggestion
+
+#Style - Pattern matching
+
+#prefer is expression with type casts instead of pattern matching
+csharp_style_pattern_matching_over_as_with_null_check = false:suggestion
+
+#Style - qualification options
+
+#prefer events not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_event = false:suggestion
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_method = false:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/Assets/Editor/AspectRatio.cs
+++ b/Assets/Editor/AspectRatio.cs
@@ -5,12 +5,13 @@
     /// </summary>
     public enum AspectRatio
     {
-	    OneOne,
-		TwoOne,
-		OneTwo
-	}
+        OneOne,
+        TwoOne,
+        OneTwo
+    }
 
-    public static class AspectRatioUtility {
-	    public static string[] aspectRatioNames = {"1:1", "2:1", "1:2"};
+    public static class AspectRatioUtility
+    {
+        public static string[] aspectRatioNames = { "1:1", "2:1", "1:2" };
     }
 }

--- a/Assets/Editor/Asset.cs
+++ b/Assets/Editor/Asset.cs
@@ -8,416 +8,416 @@ using UnityEngine;
 
 namespace ParkitectAssetEditor
 {
-	/// <summary>
-	/// Represents an asset that will be loaded in Parkitect.
-	/// </summary>
-	public class Asset
-	{
-
-		/// <summary>
-		/// Gets or sets the unique identifier.
-		/// </summary>
-		/// <value>
-		/// The unique identifier.
-		/// </value>
-		public string Guid { get; set; }
-
-		/// <summary>
-		/// The name
-		/// </summary>
-		private string _name;
-
-		/// <summary>
-		/// Gets or sets the name.
-		/// </summary>
-		/// <value>
-		/// The name.
-		/// </value>
-		public string Name
-		{
-			get { return _name; }
-			set
-			{
-				_name = value;
-				if (GameObject != null) GameObject.name = _name;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the type.
-		/// </summary>
-		/// <value>
-		/// The type.
-		/// </value>
-		public AssetType Type { get; set; }
-
-		/// <summary>
-		/// Gets or sets the price.
-		/// </summary>
-		/// <value>
-		/// The price.
-		/// </value>
-		public float Price { get; set; }
-
-		/// <summary>
-		/// Gets or sets the category.
-		/// </summary>
-		/// <value>
-		/// The category.
-		/// </value>
-		public string Category { get; set; }
-
-		/// <summary>
-		/// Gets or sets the sub category.
-		/// </summary>
-		/// <value>
-		/// The sub category.
-		/// </value>
-		public string SubCategory { get; set; }
-
-		#region deco
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this asset builds on a grid.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if asset builds on a grid; otherwise, <c>false</c>.
-		/// </value>
-		public bool BuildOnGrid { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this asset snaps to the center of a tile.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if snaps to center; otherwise, <c>false</c>.
-		/// </value>
-		public bool SnapCenter { get; set; }
-
-		/// <summary>
-		/// Gets or sets the grid size.
-		/// </summary>
-		/// <value>
-		/// The grid size.
-		/// </value>
-		public float GridSubdivision { get; set; }
-
-		/// <summary>
-		/// Gets or sets the height delta.
-		/// </summary>
-		/// <value>
-		/// The height delta.
-		/// </value>
-		public float HeightDelta { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this instance has custom colors.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this instance has custom colors; otherwise, <c>false</c>.
-		/// </value>
-		public bool HasCustomColors { get; set; }
-
-		/// <summary>
-		/// The colors
-		/// </summary>
-		[JsonIgnore] public Color[] Colors = new Color[4];
-
-		/// <summary>
-		/// Property to support serializing for Unity's color struct
-		/// </summary>
-		public CustomColor[] CustomColors
-		{
-			get { return Colors.Select(c => new CustomColor {Red = c.r, Green = c.g, Blue = c.b, Alpha = c.a}).ToArray(); }
-			set { Colors = value.Select(c => new Color(c.Red, c.Green, c.Blue, c.Alpha)).ToArray(); }
-		}
-
-		/// <summary>
-		/// Gets or sets the amount of custom colors this asset has.
-		/// </summary>
-		/// <value>
-		/// The color count.
-		/// </value>
-		public int ColorCount { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this instance is resizable.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this instance is resizable; otherwise, <c>false</c>.
-		/// </value>
-		public bool IsResizable { get; set; }
-
-		/// <summary>
-		/// Gets or sets the minimum size.
-		/// </summary>
-		/// <value>
-		/// The minimum size.
-		/// </value>
-		public float MinSize { get; set; }
-
-		/// <summary>
-		/// Gets or sets the maximum size.
-		/// </summary>
-		/// <value>
-		/// The maximum size.
-		/// </value>
-		public float MaxSize { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this object blocks visibility.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if [see through]; otherwise, <c>false</c>.
-		/// </value>
-		public bool CanSeeThrough { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this object blocks rain.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if [blocks rain]; otherwise, <c>false</c>.
-		/// </value>
-		public bool BlocksRain { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this object has lights that should turn on at night.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if [lights should turn on at night]; otherwise, <c>false</c>.
-		/// </value>
-		public bool LightsTurnOnAtNight { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether lights on this object should use custom colors.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if [lights should use custom colors]; otherwise, <c>false</c>.
-		/// </value>
-		public bool LightsUseCustomColors { get; set; }
-
-		/// <summary>
-		/// Gets or sets the custom color slot to use by this light.
-		/// </summary>
-		/// <value>
-		/// The custom color slot
-		/// </value>
-		public int LightsCustomColorSlot { get; set; }
-		
-		public bool EffectsTriggerEnabled { get; set; }
-		public bool EffectsTriggerCustomizableDuration { get; set; }
-
-		#endregion
-
-		#region bench
-
-		/// <summary>
-		/// Gets or sets a value indicating whether the bench has a back rest.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if the bench has back a rest; otherwise, <c>false</c>.
-		/// </value>
-		public bool HasBackRest { get; set; }
-
-		#endregion
-
-		#region fence
-
-		/// <summary>
-		/// Gets or sets the fence post GO.
-		/// </summary>
-		/// <value>
-		/// The fence post GO.
-		/// </value>
-		[JsonIgnore]
-		public GameObject FencePost
-		{
-			get { return GameObjectHashMap.Instance.Get(Guid + ".post"); }
-			set { GameObjectHashMap.Instance.Set(Guid + ".post", value); }
-		}
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this instance has a post.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this instance has a post; otherwise, <c>false</c>.
-		/// </value>
-		public bool HasMidPost { get; set; }
-
-		#endregion
-
-		#region wall
-
-		public int WallSettings;
-
-		public float Height;
-		
-		#endregion
-
-		#region flatride
-
-		public string Description;
-
-		/// <summary>
-		/// Get or sets a value indicating how protected against rain a ride is bounded between 0 and 1
-		/// </summary>
-		public float RainProtection;
-
-		/// <summary>
-		/// Get or sets a value indicating how exciting a ride is bounded between 0 and 1
-		/// </summary>
-		public float Excitement;
-
-		/// <summary>
-		/// Get or sets a value indicating how intense a ride is bounded between 0 and 1
-		/// </summary>
-		public float Intensity;
-
-		/// <summary>
-		/// Get or sets a value indicating how nausea a ride is bounded between 0 and 1
-		/// </summary>
-		public float Nausea;
-
-		/// <summary>
-		/// Determines the x footprint size
-		/// </summary>
-		public int FootprintX = 1;
-
-		/// <summary>
-		/// Determines the y footprint size
-		/// </summary>
-		public int FootprintZ = 1;
-
-		/// <summary>
-		/// Category of flatride
-		/// </summary>
-		public string FlatRideCategory = AttractionType.CategoryTag[0];
-
-		#endregion
-
-		#region trains
-
-		public string TrackedRideName;
-
-		public int DefaultTrainLength = 1;
-		public int MinTrainLength = 1;
-		public int MaxTrainLength = 1;
-
-		public CoasterCar LeadCar;
-		public CoasterCar Car;
-		public CoasterCar RearCar;
-
-		#endregion
-
-		#region BoundingBoxes
-
-		[JsonIgnore] 
-		public bool EnableBoundingBoxEditing;
-
-		
-		/// <summary>
-		/// determins if the bounding box can snap
-		/// </summary>
-		[JsonIgnore] 
-		public bool BoundingBoxSnap;
-
-		/// <summary>
-		/// the active bounded box
-		/// </summary>
-		[JsonIgnore] 
-		public BoundingBox SelectedBoundingBox = null;
-
-		/// <summary>
-		/// Bounded box regions
-		/// </summary>
-		public List<BoundingBox> BoundingBoxes = new List<BoundingBox>();
-
-		#endregion
-
-		#region waypoints
-
-		/// <summary>
-		/// list of waypoints to help with NPC traversial 
-		/// </summary>
-		public List<Waypoint> Waypoints = new List<Waypoint>();
-
-		[JsonIgnore] public bool EnableWaypointEditing;
-
-		/// <summary>
-		/// Helper Y Plane, used to place waypoints
-		/// </summary>
-		[JsonIgnore] public float HelperPlaneY;
-
-		/// <summary>
-		/// The currently selected waypoint
-		/// </summary>
-		[JsonIgnore] public Waypoint SelectedWaypoint;
-
-		/// <summary>
-		/// The state of the waypoint editor
-		/// </summary>
-		[JsonIgnore] public WaypointRenderer.WaypointState WaypointState;
-
-		#endregion
-
-		#region sign        
-
-		/// <summary>
-		/// Gets or sets the text game object.
-		/// </summary>
-		/// <value>
-		/// The text game object.
-		/// </value>
-		[JsonIgnore]
-		public GameObject Text
-		{
-			get { return GameObjectHashMap.Instance.Get(Guid + ".text"); }
-			set { GameObjectHashMap.Instance.Set(Guid + ".text", value); }
-		}
-
-		#endregion
-
-		#region sign        
-
-		/// <summary>
-		/// Gets or sets the screen game object.
-		/// </summary>
-		/// <value>
-		/// The screen game object.
-		/// </value>
-		[JsonIgnore]
-		public GameObject Screen
-		{
-			get { return GameObjectHashMap.Instance.Get(Guid + ".screen"); }
-			set { GameObjectHashMap.Instance.Set(Guid + ".screen", value); }
-		}
-
-		#endregion
-
-		public AspectRatio AspectRatio { get; set; }
-
-		/// <summary>
-		/// Gets or sets the game object.
-		/// </summary>
-		/// <value>
-		/// The game object.
-		/// </value>
-		[JsonIgnore]
-		public GameObject GameObject
-		{
-			get { return GameObjectHashMap.Instance.Get(Guid); }
-			set { GameObjectHashMap.Instance.Set(Guid, value); }
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Asset"/> class.
-		/// </summary>
-		public Asset()
-		{
-			Guid = GUID.Generate().ToString(); // don't need the object, just make it a string immediately
-			MinSize = 1;
-			MaxSize = 1;
+    /// <summary>
+    /// Represents an asset that will be loaded in Parkitect.
+    /// </summary>
+    public class Asset
+    {
+
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        /// <value>
+        /// The unique identifier.
+        /// </value>
+        public string Guid { get; set; }
+
+        /// <summary>
+        /// The name
+        /// </summary>
+        private string _name;
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
+        public string Name
+        {
+            get { return _name; }
+            set
+            {
+                _name = value;
+                if (GameObject != null) GameObject.name = _name;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
+        public AssetType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the price.
+        /// </summary>
+        /// <value>
+        /// The price.
+        /// </value>
+        public float Price { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category.
+        /// </summary>
+        /// <value>
+        /// The category.
+        /// </value>
+        public string Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sub category.
+        /// </summary>
+        /// <value>
+        /// The sub category.
+        /// </value>
+        public string SubCategory { get; set; }
+
+        #region deco
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this asset builds on a grid.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if asset builds on a grid; otherwise, <c>false</c>.
+        /// </value>
+        public bool BuildOnGrid { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this asset snaps to the center of a tile.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if snaps to center; otherwise, <c>false</c>.
+        /// </value>
+        public bool SnapCenter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the grid size.
+        /// </summary>
+        /// <value>
+        /// The grid size.
+        /// </value>
+        public float GridSubdivision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the height delta.
+        /// </summary>
+        /// <value>
+        /// The height delta.
+        /// </value>
+        public float HeightDelta { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has custom colors.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance has custom colors; otherwise, <c>false</c>.
+        /// </value>
+        public bool HasCustomColors { get; set; }
+
+        /// <summary>
+        /// The colors
+        /// </summary>
+        [JsonIgnore] public Color[] Colors = new Color[4];
+
+        /// <summary>
+        /// Property to support serializing for Unity's color struct
+        /// </summary>
+        public CustomColor[] CustomColors
+        {
+            get { return Colors.Select(c => new CustomColor { Red = c.r, Green = c.g, Blue = c.b, Alpha = c.a }).ToArray(); }
+            set { Colors = value.Select(c => new Color(c.Red, c.Green, c.Blue, c.Alpha)).ToArray(); }
+        }
+
+        /// <summary>
+        /// Gets or sets the amount of custom colors this asset has.
+        /// </summary>
+        /// <value>
+        /// The color count.
+        /// </value>
+        public int ColorCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is resizable.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is resizable; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsResizable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum size.
+        /// </summary>
+        /// <value>
+        /// The minimum size.
+        /// </value>
+        public float MinSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum size.
+        /// </summary>
+        /// <value>
+        /// The maximum size.
+        /// </value>
+        public float MaxSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this object blocks visibility.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [see through]; otherwise, <c>false</c>.
+        /// </value>
+        public bool CanSeeThrough { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this object blocks rain.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [blocks rain]; otherwise, <c>false</c>.
+        /// </value>
+        public bool BlocksRain { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this object has lights that should turn on at night.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [lights should turn on at night]; otherwise, <c>false</c>.
+        /// </value>
+        public bool LightsTurnOnAtNight { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether lights on this object should use custom colors.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [lights should use custom colors]; otherwise, <c>false</c>.
+        /// </value>
+        public bool LightsUseCustomColors { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom color slot to use by this light.
+        /// </summary>
+        /// <value>
+        /// The custom color slot
+        /// </value>
+        public int LightsCustomColorSlot { get; set; }
+
+        public bool EffectsTriggerEnabled { get; set; }
+        public bool EffectsTriggerCustomizableDuration { get; set; }
+
+        #endregion
+
+        #region bench
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the bench has a back rest.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the bench has back a rest; otherwise, <c>false</c>.
+        /// </value>
+        public bool HasBackRest { get; set; }
+
+        #endregion
+
+        #region fence
+
+        /// <summary>
+        /// Gets or sets the fence post GO.
+        /// </summary>
+        /// <value>
+        /// The fence post GO.
+        /// </value>
+        [JsonIgnore]
+        public GameObject FencePost
+        {
+            get { return GameObjectHashMap.Instance.Get(Guid + ".post"); }
+            set { GameObjectHashMap.Instance.Set(Guid + ".post", value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has a post.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance has a post; otherwise, <c>false</c>.
+        /// </value>
+        public bool HasMidPost { get; set; }
+
+        #endregion
+
+        #region wall
+
+        public int WallSettings;
+
+        public float Height;
+
+        #endregion
+
+        #region flatride
+
+        public string Description;
+
+        /// <summary>
+        /// Get or sets a value indicating how protected against rain a ride is bounded between 0 and 1
+        /// </summary>
+        public float RainProtection;
+
+        /// <summary>
+        /// Get or sets a value indicating how exciting a ride is bounded between 0 and 1
+        /// </summary>
+        public float Excitement;
+
+        /// <summary>
+        /// Get or sets a value indicating how intense a ride is bounded between 0 and 1
+        /// </summary>
+        public float Intensity;
+
+        /// <summary>
+        /// Get or sets a value indicating how nausea a ride is bounded between 0 and 1
+        /// </summary>
+        public float Nausea;
+
+        /// <summary>
+        /// Determines the x footprint size
+        /// </summary>
+        public int FootprintX = 1;
+
+        /// <summary>
+        /// Determines the y footprint size
+        /// </summary>
+        public int FootprintZ = 1;
+
+        /// <summary>
+        /// Category of flatride
+        /// </summary>
+        public string FlatRideCategory = AttractionType.CategoryTag[0];
+
+        #endregion
+
+        #region trains
+
+        public string TrackedRideName;
+
+        public int DefaultTrainLength = 1;
+        public int MinTrainLength = 1;
+        public int MaxTrainLength = 1;
+
+        public CoasterCar LeadCar;
+        public CoasterCar Car;
+        public CoasterCar RearCar;
+
+        #endregion
+
+        #region BoundingBoxes
+
+        [JsonIgnore]
+        public bool EnableBoundingBoxEditing;
+
+
+        /// <summary>
+        /// determins if the bounding box can snap
+        /// </summary>
+        [JsonIgnore]
+        public bool BoundingBoxSnap;
+
+        /// <summary>
+        /// the active bounded box
+        /// </summary>
+        [JsonIgnore]
+        public BoundingBox SelectedBoundingBox = null;
+
+        /// <summary>
+        /// Bounded box regions
+        /// </summary>
+        public List<BoundingBox> BoundingBoxes = new List<BoundingBox>();
+
+        #endregion
+
+        #region waypoints
+
+        /// <summary>
+        /// list of waypoints to help with NPC traversial 
+        /// </summary>
+        public List<Waypoint> Waypoints = new List<Waypoint>();
+
+        [JsonIgnore] public bool EnableWaypointEditing;
+
+        /// <summary>
+        /// Helper Y Plane, used to place waypoints
+        /// </summary>
+        [JsonIgnore] public float HelperPlaneY;
+
+        /// <summary>
+        /// The currently selected waypoint
+        /// </summary>
+        [JsonIgnore] public Waypoint SelectedWaypoint;
+
+        /// <summary>
+        /// The state of the waypoint editor
+        /// </summary>
+        [JsonIgnore] public WaypointRenderer.WaypointState WaypointState;
+
+        #endregion
+
+        #region sign        
+
+        /// <summary>
+        /// Gets or sets the text game object.
+        /// </summary>
+        /// <value>
+        /// The text game object.
+        /// </value>
+        [JsonIgnore]
+        public GameObject Text
+        {
+            get { return GameObjectHashMap.Instance.Get(Guid + ".text"); }
+            set { GameObjectHashMap.Instance.Set(Guid + ".text", value); }
+        }
+
+        #endregion
+
+        #region sign        
+
+        /// <summary>
+        /// Gets or sets the screen game object.
+        /// </summary>
+        /// <value>
+        /// The screen game object.
+        /// </value>
+        [JsonIgnore]
+        public GameObject Screen
+        {
+            get { return GameObjectHashMap.Instance.Get(Guid + ".screen"); }
+            set { GameObjectHashMap.Instance.Set(Guid + ".screen", value); }
+        }
+
+        #endregion
+
+        public AspectRatio AspectRatio { get; set; }
+
+        /// <summary>
+        /// Gets or sets the game object.
+        /// </summary>
+        /// <value>
+        /// The game object.
+        /// </value>
+        [JsonIgnore]
+        public GameObject GameObject
+        {
+            get { return GameObjectHashMap.Instance.Get(Guid); }
+            set { GameObjectHashMap.Instance.Set(Guid, value); }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Asset"/> class.
+        /// </summary>
+        public Asset()
+        {
+            Guid = GUID.Generate().ToString(); // don't need the object, just make it a string immediately
+            MinSize = 1;
+            MaxSize = 1;
             Height = 1;
-			CanSeeThrough = true;
-		}
-	}
+            CanSeeThrough = true;
+        }
+    }
 }

--- a/Assets/Editor/AssetPack.cs
+++ b/Assets/Editor/AssetPack.cs
@@ -29,7 +29,7 @@ namespace ParkitectAssetEditor
         /// The name.
         /// </value>
         public string Name { get; set; }
-		
+
         /// <summary>
         /// A unique id per build
         /// </summary>
@@ -37,7 +37,7 @@ namespace ParkitectAssetEditor
         /// The unique identifier.
         /// </value>
         public string BuildGuid { get; set; }
-		
+
         /// <summary>
         /// A user-readable version number
         /// </summary>
@@ -63,7 +63,7 @@ namespace ParkitectAssetEditor
         /// The archive setting. If true, assets should be archived with the mod to be uploaded to the workshop.
         /// </value>
         public bool ArchiveAssets { get; set; }
-        
+
         /// <summary>
         /// Adds the specified game object as an asset.
         /// </summary>
@@ -89,7 +89,7 @@ namespace ParkitectAssetEditor
                 SubCategory = "",
                 SnapCenter = true,
                 GridSubdivision = 1,
-				HeightDelta = 0.25f
+                HeightDelta = 0.25f
             };
 
             Add(asset);
@@ -116,7 +116,7 @@ namespace ParkitectAssetEditor
 
             LayOutAssets();
         }
-        
+
         /// <summary>
         /// Removes the specified asset.
         /// </summary>

--- a/Assets/Editor/AssetPackSerializer.cs
+++ b/Assets/Editor/AssetPackSerializer.cs
@@ -35,25 +35,30 @@ namespace ParkitectAssetEditor
             var prefabPaths = new List<string>();
             foreach (var asset in assetPack.Assets)
             {
-                if (asset.Type == AssetType.Train) {
-                    if (asset.LeadCar != null) {
+                if (asset.Type == AssetType.Train)
+                {
+                    if (asset.LeadCar != null)
+                    {
                         prefabPaths.Add(CreatePrefab(asset.LeadCar.GameObject, asset.LeadCar.Guid));
                     }
-                    if (asset.Car != null) {
+                    if (asset.Car != null)
+                    {
                         prefabPaths.Add(CreatePrefab(asset.Car.GameObject, asset.Car.Guid));
                     }
-                    if (asset.RearCar != null) {
+                    if (asset.RearCar != null)
+                    {
                         prefabPaths.Add(CreatePrefab(asset.RearCar.GameObject, asset.RearCar.Guid));
                     }
                 }
-                else {
+                else
+                {
                     asset.LeadCar = null;
                     asset.Car = null;
                     asset.RearCar = null;
                     prefabPaths.Add(CreatePrefab(asset.GameObject, asset.Guid));
                 }
             }
-            
+
             // use the prefab list to build an assetbundle
             AssetBundleBuild[] descriptor = {
                 new AssetBundleBuild()
@@ -64,12 +69,14 @@ namespace ParkitectAssetEditor
             };
 
             BuildPipeline.BuildAssetBundles(ProjectManager.Project.Value.ModDirectory, descriptor, BuildAssetBundleOptions.ForceRebuildAssetBundle | BuildAssetBundleOptions.DeterministicAssetBundle | BuildAssetBundleOptions.UncompressedAssetBundle | BuildAssetBundleOptions.StrictMode, BuildTarget.StandaloneWindows);
-            
+
             return true;
         }
 
-        private static string CreatePrefab(GameObject gameObject, string Guid) {
-            if (gameObject == null) {
+        private static string CreatePrefab(GameObject gameObject, string Guid)
+        {
+            if (gameObject == null)
+            {
                 return null;
             }
 
@@ -79,7 +86,7 @@ namespace ParkitectAssetEditor
 
             return path;
         }
-        
+
         /// <summary>
         /// Fills asset pack with gameobjects from the scene and/or prefabs.
         /// </summary>
@@ -97,7 +104,7 @@ namespace ParkitectAssetEditor
                     try // if one object fails to load, don't make it fail the rest
                     {
                         var go = Resources.Load<GameObject>(string.Format("AssetPack/{0}", asset.Guid));
-                        
+
                         asset.GameObject = Object.Instantiate(go);
                         asset.GameObject.name = asset.Name;
                     }
@@ -136,7 +143,7 @@ namespace ParkitectAssetEditor
                 try // if one object fails to load, don't make it fail the rest
                 {
                     var go = Resources.Load<GameObject>(string.Format("AssetPack/{0}", Guid));
-                    
+
                     return Object.Instantiate(go);
                 }
                 catch (System.Exception)

--- a/Assets/Editor/AssetType.cs
+++ b/Assets/Editor/AssetType.cs
@@ -6,7 +6,7 @@
     public enum AssetType
     {
         Deco,
-		Wall,
+        Wall,
         Trashbin,
         Bench,
         Fence,

--- a/Assets/Editor/CoasterCar.cs
+++ b/Assets/Editor/CoasterCar.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using UnityEditor;
 using UnityEngine;
 
 namespace ParkitectAssetEditor

--- a/Assets/Editor/CoasterCar.cs
+++ b/Assets/Editor/CoasterCar.cs
@@ -7,39 +7,40 @@ namespace ParkitectAssetEditor
     public class CoasterCar
     {
         public string Guid { get; private set; }
-        
-		[JsonIgnore]
-		public GameObject GameObject
-		{
-			get { return GameObjectHashMap.Instance.Get(Guid); }
-			set { GameObjectHashMap.Instance.Set(Guid, value); }
-		}
 
-		public CoasterCarType CoasterCarType;
+        [JsonIgnore]
+        public GameObject GameObject
+        {
+            get { return GameObjectHashMap.Instance.Get(Guid); }
+            set { GameObjectHashMap.Instance.Set(Guid, value); }
+        }
+
+        public CoasterCarType CoasterCarType;
         public float SeatWaypointOffset = 0.2f;
         public float OffsetBack;
         public float OffsetFront;
-		public List<CoasterRestraints> Restraints = new List<CoasterRestraints>();
-		
-		// spinning cars
-		public float SpinFriction = 0.25f;
-		public int SpinStrength = 60;
-		public int SpinSymmetrySides = 2;
-		
-		// swinging cars
-		public float SwingMaxAngle = 90;
-		public float SwingFriction = 0.2f;
-		public float SwingArmLength = 1.1f;
-		public float SwingStrength = 1f;
-		
+        public List<CoasterRestraints> Restraints = new List<CoasterRestraints>();
 
-		public CoasterCar(string guid)
-		{
-			Guid = guid; 
-		}
-	}
+        // spinning cars
+        public float SpinFriction = 0.25f;
+        public int SpinStrength = 60;
+        public int SpinSymmetrySides = 2;
 
-    public enum CoasterCarType {
-	    Normal, Spinning, Swinging
+        // swinging cars
+        public float SwingMaxAngle = 90;
+        public float SwingFriction = 0.2f;
+        public float SwingArmLength = 1.1f;
+        public float SwingStrength = 1f;
+
+
+        public CoasterCar(string guid)
+        {
+            Guid = guid;
+        }
+    }
+
+    public enum CoasterCarType
+    {
+        Normal, Spinning, Swinging
     }
 }

--- a/Assets/Editor/CoasterRestraints.cs
+++ b/Assets/Editor/CoasterRestraints.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Newtonsoft.Json;
-using UnityEditor;
-using UnityEngine;
-
-namespace ParkitectAssetEditor
+﻿namespace ParkitectAssetEditor
 {
     public class CoasterRestraints
     {

--- a/Assets/Editor/CoasterRestraints.cs
+++ b/Assets/Editor/CoasterRestraints.cs
@@ -2,7 +2,7 @@
 {
     public class CoasterRestraints
     {
-		public string TransformName;
+        public string TransformName;
         public float ClosedAngle;
-	}
+    }
 }

--- a/Assets/Editor/Compression/ArchiveHelper.cs
+++ b/Assets/Editor/Compression/ArchiveHelper.cs
@@ -16,7 +16,7 @@ namespace ParkitectAssetEditor.Compression
             var zipStream = new ZipOutputStream(File.Create(outPathname));
 
             zipStream.SetLevel(9); // highest level
-            
+
             // This setting will strip the leading part of the folder path in the entries, to
             // make the entries relative to the starting folder.
             var folderOffset = folderName.Length + (folderName.EndsWith("\\") ? 0 : 1);
@@ -43,7 +43,7 @@ namespace ParkitectAssetEditor.Compression
 
                 var entryName = file.Substring(folderOffset); // Makes the name in zip based on the folder
                 entryName = ZipEntry.CleanName(entryName); // Removes drive from name and fixes slash direction
-                
+
                 zipStream.PutNextEntry(new ZipEntry(entryName)
                 {
                     DateTime = fileInfo.LastWriteTime,

--- a/Assets/Editor/CustomColor.cs
+++ b/Assets/Editor/CustomColor.cs
@@ -1,13 +1,13 @@
 ﻿namespace ParkitectAssetEditor
 {
-	/// <summary>
-	/// Holds a custom color for an asset.
-	/// </summary>
-	public class CustomColor
-	{
-		public float Red;
-		public float Blue;
-		public float Green;
-		public float Alpha;
-	}
+    /// <summary>
+    /// Holds a custom color for an asset.
+    /// </summary>
+    public class CustomColor
+    {
+        public float Red;
+        public float Blue;
+        public float Green;
+        public float Alpha;
+    }
 }

--- a/Assets/Editor/CustomColorSlot.cs
+++ b/Assets/Editor/CustomColorSlot.cs
@@ -5,9 +5,9 @@
     /// </summary>
     enum CustomColorSlot
     {
-	    Color1 = 0,
-		Color2 = 1,
-		Color3 = 2,
-		Color4 = 3
-	}
+        Color1 = 0,
+        Color2 = 1,
+        Color3 = 2,
+        Color4 = 3
+    }
 }

--- a/Assets/Editor/EditorHandles_UnityInternal.cs
+++ b/Assets/Editor/EditorHandles_UnityInternal.cs
@@ -12,49 +12,56 @@ using UnityEditor;
 using UnityEngine;
 
 [InitializeOnLoad]
-public static class EditorHandles_UnityInternal {
+public static class EditorHandles_UnityInternal
+{
     static Type type_HandleUtility;
     static MethodInfo meth_IntersectRayMesh;
     static MethodInfo meth_PickObjectMeth;
- 
-    static EditorHandles_UnityInternal() {
+
+    static EditorHandles_UnityInternal()
+    {
         var editorTypes = typeof(Editor).Assembly.GetTypes();
- 
+
         type_HandleUtility = editorTypes.FirstOrDefault(t => t.Name == "HandleUtility");
         meth_IntersectRayMesh = type_HandleUtility.GetMethod("IntersectRayMesh",
                                                               BindingFlags.Static | BindingFlags.NonPublic);
         meth_PickObjectMeth = type_HandleUtility.GetMethod("PickGameObject",
                                                             BindingFlags.Static | BindingFlags.Public,
                                                             null,
-                                                            new [] {typeof(Vector2), typeof(bool)},
+                                                            new[] { typeof(Vector2), typeof(bool) },
                                                             null);
     }
- 
- 
+
+
     //get a point from interected with any meshes in scene, based on mouse position.
     //WE DON'T NOT NEED to have to have colliders ;)
     //usually used in conjunction with  PickGameObject()
-    public static bool IntersectRayMesh(Ray ray, MeshFilter meshFilter, out RaycastHit hit) {
+    public static bool IntersectRayMesh(Ray ray, MeshFilter meshFilter, out RaycastHit hit)
+    {
         return IntersectRayMesh(ray, meshFilter.sharedMesh, meshFilter.transform.localToWorldMatrix, out hit);
     }
- 
+
     //get a point from interected with any meshes in scene, based on mouse position.
     //WE DON'T NOT NEED to have to have colliders ;)
     //usually used in conjunction with  PickGameObject()
-    public static bool IntersectRayMesh(Ray ray, Mesh mesh, Matrix4x4 matrix, out RaycastHit hit) {
+    public static bool IntersectRayMesh(Ray ray, Mesh mesh, Matrix4x4 matrix, out RaycastHit hit)
+    {
         var parameters = new object[] { ray, mesh, matrix, null };
         bool result = (bool)meth_IntersectRayMesh.Invoke(null, parameters);
         hit = (RaycastHit)parameters[3];
         return result;
     }
- 
-    public static bool IntersectRayGameObject(Ray ray, GameObject gameObject, out SceneRaycastHit hit) {
+
+    public static bool IntersectRayGameObject(Ray ray, GameObject gameObject, out SceneRaycastHit hit)
+    {
         hit = new SceneRaycastHit();
         float nearestHitDistance = float.MaxValue;
         bool hitSomething = false;
-        foreach (MeshFilter meshFilter in gameObject.GetComponentsInChildren<MeshFilter>()) {
+        foreach (MeshFilter meshFilter in gameObject.GetComponentsInChildren<MeshFilter>())
+        {
             RaycastHit meshFilterHit = new RaycastHit();
-            if (IntersectRayMesh(ray, meshFilter, out meshFilterHit) && meshFilterHit.distance < nearestHitDistance) {
+            if (IntersectRayMesh(ray, meshFilter, out meshFilterHit) && meshFilterHit.distance < nearestHitDistance)
+            {
                 nearestHitDistance = meshFilterHit.distance;
                 hit.point = meshFilterHit.point;
                 hit.normal = meshFilterHit.normal;
@@ -79,26 +86,29 @@ public static class EditorHandles_UnityInternal {
 
         return hitSomething;
     }
- 
-//select a gameObject in scene, based on mouse position.
+
+    //select a gameObject in scene, based on mouse position.
     //Object DOES NOT NEED to have to have colliders ;)
     //If you DON'T want object to be included into  Selection.activeGameObject,
     //(parameter works only in gui functions and scene view delegates) specify updateSelection = false
-    public static GameObject PickGameObject(Vector2 position, bool updateSelection = true, bool selectPrefabRoot = false) {
- 
-        if (updateSelection == false && Event.current != null) {
+    public static GameObject PickGameObject(Vector2 position, bool updateSelection = true, bool selectPrefabRoot = false)
+    {
+
+        if (updateSelection == false && Event.current != null)
+        {
             int blocking_ix = GUIUtility.GetControlID(FocusType.Passive);
             HandleUtility.AddDefaultControl(blocking_ix);
             GUIUtility.hotControl = blocking_ix; //tell unity that your control is active now, so it won't do selections etc.
         }
- 
+
         GameObject pickedGameObject = (GameObject)meth_PickObjectMeth.Invoke(null,
                                                        new object[] { position, selectPrefabRoot });
- 
+
         return pickedGameObject;
     }
- 
-    public struct SceneRaycastHit {
+
+    public struct SceneRaycastHit
+    {
         public Vector3 point;
         public Vector3 normal;
         public Transform transform;

--- a/Assets/Editor/GizmoRenderers/BoundingBoxRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/BoundingBoxRenderer.cs
@@ -5,146 +5,146 @@ using UnityEngine.Rendering;
 
 namespace ParkitectAssetEditor.GizmoRenderers
 {
-	public class BoundingBoxRenderer : IGizmoRenderer, IHandleRenderer
-	{
-		public bool CanRender(Asset asset)
-		{
-			return asset.Type == AssetType.FlatRide;
-		}
+    public class BoundingBoxRenderer : IGizmoRenderer, IHandleRenderer
+    {
+        public bool CanRender(Asset asset)
+        {
+            return asset.Type == AssetType.FlatRide;
+        }
 
-		public void Render(Asset asset)
-		{
+        public void Render(Asset asset)
+        {
+        }
 
-		}
+        public void Handle(Asset asset)
+        {
+            DrawBoxes(asset);
+        }
 
-		public void Handle(Asset asset)
-		{
-			DrawBoxes(asset);
-		}
+        private void drawPlane(Vector3 p1, Vector3 p2, Vector3 p3, Vector3 p4, Color fill, Color outer, Asset asset)
+        {
+            Handles.DrawSolidRectangleWithOutline(
+                new[]
+                {
+                    asset.GameObject.transform.TransformPoint(p1), asset.GameObject.transform.TransformPoint(p2),
+                    asset.GameObject.transform.TransformPoint(p3), asset.GameObject.transform.TransformPoint(p4)
+                }, fill, outer);
+        }
 
-		private void drawPlane(Vector3 p1, Vector3 p2, Vector3 p3, Vector3 p4, Color fill, Color outer, Asset asset)
-		{
-			Handles.DrawSolidRectangleWithOutline(
-				new[]
-				{
-					asset.GameObject.transform.TransformPoint(p1), asset.GameObject.transform.TransformPoint(p2),
-					asset.GameObject.transform.TransformPoint(p3), asset.GameObject.transform.TransformPoint(p4)
-				}, fill, outer);
-		}
+        private void DrawBoxes(Asset asset)
+        {
+            foreach (BoundingBox box in asset.BoundingBoxes)
+            {
+                if (box == asset.SelectedBoundingBox)
+                {
+                    // EditorUtility.SetDirty(PMM);
+                    Tools.current = Tool.None;
 
-		private void DrawBoxes(Asset asset)
-		{
-			foreach (BoundingBox box in asset.BoundingBoxes)
-			{
-				if (box == asset.SelectedBoundingBox) {
-					// EditorUtility.SetDirty(PMM);
-					Tools.current = Tool.None;
+                    int controlID = GUIUtility.GetControlID(GetHashCode(), FocusType.Passive);
+                    switch (Event.current.type)
+                    {
+                        case EventType.Layout:
+                            HandleUtility.AddDefaultControl(controlID);
+                            break;
+                        case EventType.KeyDown:
+                            if (Event.current.keyCode == KeyCode.S)
+                            {
+                                asset.BoundingBoxSnap = true;
+                            }
 
-					int controlID = GUIUtility.GetControlID(GetHashCode(), FocusType.Passive);
-					switch (Event.current.type)
-					{
-						case EventType.Layout:
-							HandleUtility.AddDefaultControl(controlID);
-							break;
-						case EventType.KeyDown:
-							if (Event.current.keyCode == KeyCode.S)
-							{
-								asset.BoundingBoxSnap = true;
-							}
+                            break;
+                        case EventType.KeyUp:
+                            if (Event.current.keyCode == KeyCode.S)
+                            {
+                                asset.BoundingBoxSnap = false;
+                            }
 
-							break;
-						case EventType.KeyUp:
-							if (Event.current.keyCode == KeyCode.S)
-							{
-								asset.BoundingBoxSnap = false;
-							}
+                            break;
+                    }
+                }
 
-							break;
-					}
-				}
+                Vector3 diff = box.Bounds.max - box.Bounds.min;
+                Vector3 diffX = new Vector3(diff.x, 0, 0);
+                Vector3 diffY = new Vector3(0, diff.y, 0);
+                Vector3 diffZ = new Vector3(0, 0, diff.z);
 
-				Vector3 diff = box.Bounds.max - box.Bounds.min;
-				Vector3 diffX = new Vector3(diff.x, 0, 0);
-				Vector3 diffY = new Vector3(0, diff.y, 0);
-				Vector3 diffZ = new Vector3(0, 0, diff.z);
+                Color fill = Color.white;
+                fill.a = 0.005f;
+                Color outer = Color.gray;
+                if (box == asset.SelectedBoundingBox)
+                {
+                    fill = Color.magenta;
+                    fill.a = 0.05f;
+                    outer = Color.black;
+                }
 
-				Color fill = Color.white;
-				fill.a = 0.005f;
-				Color outer = Color.gray;
-				if (box == asset.SelectedBoundingBox)
-				{
-					fill = Color.magenta;
-					fill.a = 0.05f;
-					outer = Color.black;
-				}
-				
-				Handles.zTest = CompareFunction.Less;
+                Handles.zTest = CompareFunction.Less;
 
-				// left
-				drawPlane(box.Bounds.min, box.Bounds.min + diffZ, box.Bounds.min + diffZ + diffY,
-					box.Bounds.min + diffY, fill, outer, asset);
+                // left
+                drawPlane(box.Bounds.min, box.Bounds.min + diffZ, box.Bounds.min + diffZ + diffY,
+                    box.Bounds.min + diffY, fill, outer, asset);
 
-				//back
-				drawPlane(box.Bounds.min, box.Bounds.min + diffX, box.Bounds.min + diffX + diffY,
-					box.Bounds.min + diffY, fill, outer, asset);
+                //back
+                drawPlane(box.Bounds.min, box.Bounds.min + diffX, box.Bounds.min + diffX + diffY,
+                    box.Bounds.min + diffY, fill, outer, asset);
 
-				//right
-				drawPlane(box.Bounds.max, box.Bounds.max - diffY, box.Bounds.max - diffY - diffZ,
-					box.Bounds.max - diffZ, fill, outer, asset);
+                //right
+                drawPlane(box.Bounds.max, box.Bounds.max - diffY, box.Bounds.max - diffY - diffZ,
+                    box.Bounds.max - diffZ, fill, outer, asset);
 
-				//forward
-				drawPlane(box.Bounds.max, box.Bounds.max - diffY, box.Bounds.max - diffY - diffX,
-					box.Bounds.max - diffX, fill, outer, asset);
+                //forward
+                drawPlane(box.Bounds.max, box.Bounds.max - diffY, box.Bounds.max - diffY - diffX,
+                    box.Bounds.max - diffX, fill, outer, asset);
 
-				//up
-				drawPlane(box.Bounds.max, box.Bounds.max - diffX, box.Bounds.max - diffX - diffZ,
-					box.Bounds.max - diffZ, fill, outer, asset);
+                //up
+                drawPlane(box.Bounds.max, box.Bounds.max - diffX, box.Bounds.max - diffX - diffZ,
+                    box.Bounds.max - diffZ, fill, outer, asset);
 
-				//down
-				drawPlane(box.Bounds.min, box.Bounds.min + diffX, box.Bounds.min + diffX + diffZ,
-					box.Bounds.min + diffZ, fill, outer, asset);
+                //down
+                drawPlane(box.Bounds.min, box.Bounds.min + diffX, box.Bounds.min + diffX + diffZ,
+                    box.Bounds.min + diffZ, fill, outer, asset);
 
-				Handles.zTest = CompareFunction.Always;
+                Handles.zTest = CompareFunction.Always;
 
-				if (box == asset.SelectedBoundingBox)
-				{
-					box.Bounds.min = handleModifyValue(box.Bounds.min,
-						asset.GameObject.transform.InverseTransformPoint(Handles.PositionHandle(
-							asset.GameObject.transform.TransformPoint(box.Bounds.min),
-							Quaternion.LookRotation(Vector3.left, Vector3.down))), asset.BoundingBoxSnap);
+                if (box == asset.SelectedBoundingBox)
+                {
+                    box.Bounds.min = handleModifyValue(box.Bounds.min,
+                        asset.GameObject.transform.InverseTransformPoint(Handles.PositionHandle(
+                            asset.GameObject.transform.TransformPoint(box.Bounds.min),
+                            Quaternion.LookRotation(Vector3.left, Vector3.down))), asset.BoundingBoxSnap);
 
-					box.Bounds.max = handleModifyValue(box.Bounds.max,
-						asset.GameObject.transform.InverseTransformPoint(Handles.PositionHandle(
-							asset.GameObject.transform.TransformPoint(box.Bounds.max),
-							Quaternion.LookRotation(Vector3.forward))), asset.BoundingBoxSnap);
-					Handles.Label(asset.GameObject.transform.position + box.Bounds.min, box.Bounds.min.ToString("F2"));
-					Handles.Label(asset.GameObject.transform.position + box.Bounds.max, box.Bounds.max.ToString("F2"));
-				}
-			}
-		}
+                    box.Bounds.max = handleModifyValue(box.Bounds.max,
+                        asset.GameObject.transform.InverseTransformPoint(Handles.PositionHandle(
+                            asset.GameObject.transform.TransformPoint(box.Bounds.max),
+                            Quaternion.LookRotation(Vector3.forward))), asset.BoundingBoxSnap);
+                    Handles.Label(asset.GameObject.transform.position + box.Bounds.min, box.Bounds.min.ToString("F2"));
+                    Handles.Label(asset.GameObject.transform.position + box.Bounds.max, box.Bounds.max.ToString("F2"));
+                }
+            }
+        }
 
-		private Vector3 handleModifyValue(Vector3 value, Vector3 newValue, bool snap)
-		{
-			if (snap && (newValue - value).magnitude > Mathf.Epsilon)
-			{
-				if (Mathf.Abs(newValue.x - value.x) > Mathf.Epsilon)
-				{
-					newValue.x = Mathf.Round(newValue.x * 4) / 4;
-				}
+        private Vector3 handleModifyValue(Vector3 value, Vector3 newValue, bool snap)
+        {
+            if (snap && (newValue - value).magnitude > Mathf.Epsilon)
+            {
+                if (Mathf.Abs(newValue.x - value.x) > Mathf.Epsilon)
+                {
+                    newValue.x = Mathf.Round(newValue.x * 4) / 4;
+                }
 
-				if (Mathf.Abs(newValue.y - value.y) > Mathf.Epsilon)
-				{
-					newValue.y = Mathf.Round(newValue.y * 4) / 4;
-				}
+                if (Mathf.Abs(newValue.y - value.y) > Mathf.Epsilon)
+                {
+                    newValue.y = Mathf.Round(newValue.y * 4) / 4;
+                }
 
-				if (Mathf.Abs(newValue.z - value.z) > Mathf.Epsilon)
-				{
-					newValue.z = Mathf.Round(newValue.z * 4) / 4;
-				}
-			}
+                if (Mathf.Abs(newValue.z - value.z) > Mathf.Epsilon)
+                {
+                    newValue.z = Mathf.Round(newValue.z * 4) / 4;
+                }
+            }
 
-			return newValue;
-		}
+            return newValue;
+        }
 
-	}
+    }
 }

--- a/Assets/Editor/GizmoRenderers/FootprintRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/FootprintRenderer.cs
@@ -22,7 +22,7 @@ namespace ParkitectAssetEditor.GizmoRenderers
             fill.a = 0.1f;
             Handles.zTest = CompareFunction.LessEqual;
             Handles.color = Color.white;
-            Handles.DrawSolidRectangleWithOutline(new[] {topLeft, topRight, bottomRight, bottomLeft}, fill, Color.black);         
+            Handles.DrawSolidRectangleWithOutline(new[] { topLeft, topRight, bottomRight, bottomLeft }, fill, Color.black);
         }
 
     }

--- a/Assets/Editor/GizmoRenderers/GridRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/GridRenderer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
 

--- a/Assets/Editor/GizmoRenderers/GridRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/GridRenderer.cs
@@ -4,45 +4,45 @@ using UnityEngine.Rendering;
 
 namespace ParkitectAssetEditor.GizmoRenderers
 {
-	/// <summary>
-	/// Renders a grid around decos and walls.
-	/// </summary>
-	/// <seealso cref="IGizmoRenderer" />
-	internal class GridRenderer : IGizmoRenderer
-	{
-		/// <summary>
-		/// Determines whether this instance can render the specified asset.
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		/// <returns>
-		///   <c>true</c> if this instance can render the specified asset; otherwise, <c>false</c>.
-		/// </returns>
-		public bool CanRender(Asset asset)
-		{
-			return asset.Type == AssetType.Deco || asset.Type == AssetType.Wall;
-		}
+    /// <summary>
+    /// Renders a grid around decos and walls.
+    /// </summary>
+    /// <seealso cref="IGizmoRenderer" />
+    internal class GridRenderer : IGizmoRenderer
+    {
+        /// <summary>
+        /// Determines whether this instance can render the specified asset.
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        /// <returns>
+        ///   <c>true</c> if this instance can render the specified asset; otherwise, <c>false</c>.
+        /// </returns>
+        public bool CanRender(Asset asset)
+        {
+            return asset.Type == AssetType.Deco || asset.Type == AssetType.Wall;
+        }
 
-		/// <summary>
-		/// Renders the specified asset.
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		public void Render(Asset asset)
-		{
-			var min = asset.SnapCenter ?  - 2.5f : -3f;
-			var max = asset.SnapCenter ? 2.5f : 3f;
+        /// <summary>
+        /// Renders the specified asset.
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        public void Render(Asset asset)
+        {
+            var min = asset.SnapCenter ? -2.5f : -3f;
+            var max = asset.SnapCenter ? 2.5f : 3f;
 
-			Handles.zTest = CompareFunction.LessEqual;
+            Handles.zTest = CompareFunction.LessEqual;
 
-			for (float x = min; x <= max; x += 1 / asset.GridSubdivision)
-			{
-				Handles.DrawLine(asset.GameObject.transform.position + new Vector3(x, 0, min), asset.GameObject.transform.position + new Vector3(x, 0, max));
-			}
-			for (float z = min; z <= max; z += 1 / asset.GridSubdivision)
-			{
-				Handles.DrawLine(asset.GameObject.transform.position + new Vector3(min, 0, z), asset.GameObject.transform.position + new Vector3(max, 0, z));
-			}
+            for (float x = min; x <= max; x += 1 / asset.GridSubdivision)
+            {
+                Handles.DrawLine(asset.GameObject.transform.position + new Vector3(x, 0, min), asset.GameObject.transform.position + new Vector3(x, 0, max));
+            }
+            for (float z = min; z <= max; z += 1 / asset.GridSubdivision)
+            {
+                Handles.DrawLine(asset.GameObject.transform.position + new Vector3(min, 0, z), asset.GameObject.transform.position + new Vector3(max, 0, z));
+            }
 
-			Handles.zTest = CompareFunction.Always;
-		}
-	}
+            Handles.zTest = CompareFunction.Always;
+        }
+    }
 }

--- a/Assets/Editor/GizmoRenderers/GridRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/GridRenderer.cs
@@ -8,7 +8,7 @@ namespace ParkitectAssetEditor.GizmoRenderers
 	/// Renders a grid around decos and walls.
 	/// </summary>
 	/// <seealso cref="IGizmoRenderer" />
-	class GridRenderer : IGizmoRenderer
+	internal class GridRenderer : IGizmoRenderer
 	{
 		/// <summary>
 		/// Determines whether this instance can render the specified asset.

--- a/Assets/Editor/GizmoRenderers/IGizmoRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/IGizmoRenderer.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace ParkitectAssetEditor.GizmoRenderers
+﻿namespace ParkitectAssetEditor.GizmoRenderers
 {
     interface IGizmoRenderer
     {

--- a/Assets/Editor/GizmoRenderers/IGizmoRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/IGizmoRenderer.cs
@@ -16,6 +16,6 @@
         /// </summary>
         /// <param name="asset">The asset.</param>
         void Render(Asset asset);
-      
+
     }
 }

--- a/Assets/Editor/GizmoRenderers/IGizmoRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/IGizmoRenderer.cs
@@ -1,6 +1,6 @@
 ﻿namespace ParkitectAssetEditor.GizmoRenderers
 {
-    interface IGizmoRenderer
+    internal interface IGizmoRenderer
     {
         /// <summary>
         /// Determines whether this instance can render the specified asset.

--- a/Assets/Editor/GizmoRenderers/IHandleRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/IHandleRenderer.cs
@@ -6,6 +6,6 @@
         /// Renders unity handles
         /// </summary>
         /// <param name="asset">The asset.</param>
-        void Handle(Asset asset);   
+        void Handle(Asset asset);
     }
 }

--- a/Assets/Editor/GizmoRenderers/SeatRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/SeatRenderer.cs
@@ -1,32 +1,32 @@
 ﻿namespace ParkitectAssetEditor.GizmoRenderers
 {
-	/// <summary>
-	/// Renders guests on a bench
-	/// </summary>
-	/// <seealso cref="IGizmoRenderer" />
-	class SeatRenderer : IGizmoRenderer
-	{		
-		/// <inheritdoc />
-		/// <summary>
-		/// Determines whether this instance can render the specified asset.
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		/// <returns>
-		///   <c>true</c> if this instance can render the specified asset; otherwise, <c>false</c>.
-		/// </returns>
-		public bool CanRender(Asset asset)
-		{
-			return asset.Type == AssetType.Bench || asset.Type == AssetType.FlatRide;
-		}
+    /// <summary>
+    /// Renders guests on a bench
+    /// </summary>
+    /// <seealso cref="IGizmoRenderer" />
+    class SeatRenderer : IGizmoRenderer
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// Determines whether this instance can render the specified asset.
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        /// <returns>
+        ///   <c>true</c> if this instance can render the specified asset; otherwise, <c>false</c>.
+        /// </returns>
+        public bool CanRender(Asset asset)
+        {
+            return asset.Type == AssetType.Bench || asset.Type == AssetType.FlatRide;
+        }
 
-		/// <inheritdoc />
-		/// <summary>
-		/// Renders the specified asset.
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		public void Render(Asset asset)
-		{
-			Utility.Utility.renderSeatGizmo(asset.GameObject);
-		}
-	}
+        /// <inheritdoc />
+        /// <summary>
+        /// Renders the specified asset.
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        public void Render(Asset asset)
+        {
+            Utility.Utility.renderSeatGizmo(asset.GameObject);
+        }
+    }
 }

--- a/Assets/Editor/GizmoRenderers/SeatRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/SeatRenderer.cs
@@ -1,10 +1,4 @@
-﻿using System.Globalization;
-using System.Linq;
-using Microsoft.CSharp;
-using UnityEditor;
-using UnityEngine;
-
-namespace ParkitectAssetEditor.GizmoRenderers
+﻿namespace ParkitectAssetEditor.GizmoRenderers
 {
 	/// <summary>
 	/// Renders guests on a bench

--- a/Assets/Editor/GizmoRenderers/TrainRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/TrainRenderer.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Linq;
-using System.Text;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Rendering;
 
 namespace ParkitectAssetEditor.GizmoRenderers
 {

--- a/Assets/Editor/GizmoRenderers/TrainRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/TrainRenderer.cs
@@ -5,128 +5,136 @@ using UnityEngine;
 
 namespace ParkitectAssetEditor.GizmoRenderers
 {
-	/// <summary>
-	/// Renders a grid around decos and walls.
-	/// </summary>
-	/// <seealso cref="IGizmoRenderer" />
-	class TrainRenderer : IGizmoRenderer
-	{
-		private Material sceneViewMaterial;
+    /// <summary>
+    /// Renders a grid around decos and walls.
+    /// </summary>
+    /// <seealso cref="IGizmoRenderer" />
+    class TrainRenderer : IGizmoRenderer
+    {
+        private Material sceneViewMaterial;
 
-		/// <summary>
-		/// Determines whether this instance can render the specified asset.
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		/// <returns>
-		///   <c>true</c> if this instance can render the specified asset; otherwise, <c>false</c>.
-		/// </returns>
-		public bool CanRender(Asset asset)
-		{
-			return asset.Type == AssetType.Train;
-		}
+        /// <summary>
+        /// Determines whether this instance can render the specified asset.
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        /// <returns>
+        ///   <c>true</c> if this instance can render the specified asset; otherwise, <c>false</c>.
+        /// </returns>
+        public bool CanRender(Asset asset)
+        {
+            return asset.Type == AssetType.Train;
+        }
 
-		/// <summary>
-		/// Renders the specified asset.
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		public void Render(Asset asset)
-		{
-			if (sceneViewMaterial == null)
-			{
-				sceneViewMaterial = (Material)AssetDatabase.LoadAssetAtPath("Assets/Editor/SceneViewGhostMaterial.mat", typeof(Material));
-			}
+        /// <summary>
+        /// Renders the specified asset.
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        public void Render(Asset asset)
+        {
+            if (sceneViewMaterial == null)
+            {
+                sceneViewMaterial = (Material)AssetDatabase.LoadAssetAtPath("Assets/Editor/SceneViewGhostMaterial.mat", typeof(Material));
+            }
 
-			CoasterCar previousCar = asset.LeadCar;
-			if (asset.Car != null && asset.Car.GameObject != null) {
-				if (previousCar != null && previousCar.GameObject != null) {
-					GameObject previousCarObject = previousCar.GameObject;
-					GameObject car = asset.Car.GameObject;
+            CoasterCar previousCar = asset.LeadCar;
+            if (asset.Car != null && asset.Car.GameObject != null)
+            {
+                if (previousCar != null && previousCar.GameObject != null)
+                {
+                    GameObject previousCarObject = previousCar.GameObject;
+                    GameObject car = asset.Car.GameObject;
 
-					float lengthAxis = 0;
-					Transform backAxisMarker = previousCarObject.transform.Find("backAxis");
-					if (backAxisMarker != null) {
-						lengthAxis = Mathf.Abs(backAxisMarker.localPosition.z);
-					}
+                    float lengthAxis = 0;
+                    Transform backAxisMarker = previousCarObject.transform.Find("backAxis");
+                    if (backAxisMarker != null)
+                    {
+                        lengthAxis = Mathf.Abs(backAxisMarker.localPosition.z);
+                    }
 
-					car.transform.position = previousCarObject.transform.position - previousCarObject.transform.forward * (lengthAxis + previousCar.OffsetBack + asset.Car.OffsetFront);
-				}
+                    car.transform.position = previousCarObject.transform.position - previousCarObject.transform.forward * (lengthAxis + previousCar.OffsetBack + asset.Car.OffsetFront);
+                }
 
-				previousCar = asset.Car;
-			}
+                previousCar = asset.Car;
+            }
 
-			if (asset.RearCar != null && asset.RearCar.GameObject != null) {
-				if (previousCar != null && previousCar.GameObject != null) {
-					GameObject previousCarObject = previousCar.GameObject;
-					GameObject car = asset.RearCar.GameObject;
+            if (asset.RearCar != null && asset.RearCar.GameObject != null)
+            {
+                if (previousCar != null && previousCar.GameObject != null)
+                {
+                    GameObject previousCarObject = previousCar.GameObject;
+                    GameObject car = asset.RearCar.GameObject;
 
-					float lengthAxis = 0;
-					Transform backAxisMarker = previousCarObject.transform.Find("backAxis");
-					if (backAxisMarker != null) {
-						lengthAxis = Mathf.Abs(backAxisMarker.localPosition.z);
-					}
+                    float lengthAxis = 0;
+                    Transform backAxisMarker = previousCarObject.transform.Find("backAxis");
+                    if (backAxisMarker != null)
+                    {
+                        lengthAxis = Mathf.Abs(backAxisMarker.localPosition.z);
+                    }
 
-					car.transform.position = previousCarObject.transform.position - previousCarObject.transform.forward * (lengthAxis + previousCar.OffsetBack + asset.RearCar.OffsetFront);
-				}
-			}
+                    car.transform.position = previousCarObject.transform.position - previousCarObject.transform.forward * (lengthAxis + previousCar.OffsetBack + asset.RearCar.OffsetFront);
+                }
+            }
 
-			DrawCar(asset.LeadCar);
-			DrawCar(asset.Car);
-			DrawCar(asset.RearCar);
-		}
+            DrawCar(asset.LeadCar);
+            DrawCar(asset.Car);
+            DrawCar(asset.RearCar);
+        }
 
-		private void DrawCar(CoasterCar car) {
-			if (car == null || car.GameObject == null)
-			{
-				return;
-			}
+        private void DrawCar(CoasterCar car)
+        {
+            if (car == null || car.GameObject == null)
+            {
+                return;
+            }
 
-			GameObject carGO = car.GameObject;
+            GameObject carGO = car.GameObject;
 
-			Utility.Utility.renderSeatGizmo(carGO);
+            Utility.Utility.renderSeatGizmo(carGO);
 
-			Color gizmoColor = Gizmos.color;
-			Gizmos.color = Color.red;
-			var seats = carGO.
-				GetComponentsInChildren<Transform>(true).Where(transform => transform.name.StartsWith("Seat", true, CultureInfo.InvariantCulture));
+            Color gizmoColor = Gizmos.color;
+            Gizmos.color = Color.red;
+            var seats = carGO.
+                GetComponentsInChildren<Transform>(true).Where(transform => transform.name.StartsWith("Seat", true, CultureInfo.InvariantCulture));
 
-			foreach (Transform seatTransform in seats)
-			{
-				Vector3 position = seatTransform.position + seatTransform.forward * car.SeatWaypointOffset - Vector3.up * 0.06f;
-				Gizmos.DrawSphere(position, 0.01f);
-			}
-			Gizmos.color = gizmoColor;
+            foreach (Transform seatTransform in seats)
+            {
+                Vector3 position = seatTransform.position + seatTransform.forward * car.SeatWaypointOffset - Vector3.up * 0.06f;
+                Gizmos.DrawSphere(position, 0.01f);
+            }
+            Gizmos.color = gizmoColor;
 
-			Gizmos.color = Color.white;
-			Vector3 frontPosition = carGO.transform.position + carGO.transform.forward * car.OffsetFront;
-			Gizmos.DrawLine(frontPosition, frontPosition + Vector3.up * 0.5f);
-			Handles.Label(frontPosition + Vector3.up * 0.5f + carGO.transform.forward * 0.1f, "Front");
+            Gizmos.color = Color.white;
+            Vector3 frontPosition = carGO.transform.position + carGO.transform.forward * car.OffsetFront;
+            Gizmos.DrawLine(frontPosition, frontPosition + Vector3.up * 0.5f);
+            Handles.Label(frontPosition + Vector3.up * 0.5f + carGO.transform.forward * 0.1f, "Front");
 
-			Transform backAxis = carGO.transform.Find("backAxis");
-			if (backAxis != null) {
-				Vector3 backPosition = backAxis.position;
-				backPosition -= carGO.transform.forward * car.OffsetBack;
+            Transform backAxis = carGO.transform.Find("backAxis");
+            if (backAxis != null)
+            {
+                Vector3 backPosition = backAxis.position;
+                backPosition -= carGO.transform.forward * car.OffsetBack;
 
-				Gizmos.DrawLine(backPosition, backPosition + Vector3.up * 0.5f);
-				Handles.Label(backPosition - Vector3.up * 0.1f - carGO.transform.forward * 0.1f, "Back");
-			}
+                Gizmos.DrawLine(backPosition, backPosition + Vector3.up * 0.5f);
+                Handles.Label(backPosition - Vector3.up * 0.1f - carGO.transform.forward * 0.1f, "Back");
+            }
 
-			foreach (CoasterRestraints restraints in car.Restraints)
-			{
-				var restraintTransforms = carGO.
-					GetComponentsInChildren<Transform>(true).Where(transform => transform.name.StartsWith(restraints.TransformName, true, CultureInfo.InvariantCulture));
+            foreach (CoasterRestraints restraints in car.Restraints)
+            {
+                var restraintTransforms = carGO.
+                    GetComponentsInChildren<Transform>(true).Where(transform => transform.name.StartsWith(restraints.TransformName, true, CultureInfo.InvariantCulture));
 
-				foreach (Transform restraintTransform in restraintTransforms)
-				{
-					MeshFilter meshFilter = restraintTransform.GetComponent<MeshFilter>();
-					if (meshFilter != null)
-					{
-						sceneViewMaterial.SetPass(0);
-						Graphics.DrawMeshNow(meshFilter.sharedMesh, restraintTransform.position, restraintTransform.rotation * Quaternion.Euler(restraints.ClosedAngle, 0, 0));
-						sceneViewMaterial.SetPass(1);
-						Graphics.DrawMeshNow(meshFilter.sharedMesh, restraintTransform.position, restraintTransform.rotation * Quaternion.Euler(restraints.ClosedAngle, 0, 0));
-					}
-				}
-			}
-		}
-	}
+                foreach (Transform restraintTransform in restraintTransforms)
+                {
+                    MeshFilter meshFilter = restraintTransform.GetComponent<MeshFilter>();
+                    if (meshFilter != null)
+                    {
+                        sceneViewMaterial.SetPass(0);
+                        Graphics.DrawMeshNow(meshFilter.sharedMesh, restraintTransform.position, restraintTransform.rotation * Quaternion.Euler(restraints.ClosedAngle, 0, 0));
+                        sceneViewMaterial.SetPass(1);
+                        Graphics.DrawMeshNow(meshFilter.sharedMesh, restraintTransform.position, restraintTransform.rotation * Quaternion.Euler(restraints.ClosedAngle, 0, 0));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Assets/Editor/GizmoRenderers/WallRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/WallRenderer.cs
@@ -7,7 +7,7 @@ namespace ParkitectAssetEditor.GizmoRenderers
     /// Renders the blocking sides of a wall.
     /// </summary>
     /// <seealso cref="IGizmoRenderer" />
-    class WallRenderer : IGizmoRenderer
+    internal class WallRenderer : IGizmoRenderer
     {
         /// <inheritdoc />
         /// <summary>

--- a/Assets/Editor/GizmoRenderers/WallRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/WallRenderer.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace ParkitectAssetEditor.GizmoRenderers

--- a/Assets/Editor/GizmoRenderers/WallRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/WallRenderer.cs
@@ -30,33 +30,34 @@ namespace ParkitectAssetEditor.GizmoRenderers
         public void Render(Asset asset)
         {
             Vector3 offset = Vector3.zero;
-            if (asset.Type == AssetType.Fence) {
+            if (asset.Type == AssetType.Fence)
+            {
                 offset = Vector3.forward / 2;
             }
 
-	        if (Convert.ToBoolean(asset.WallSettings & (int) WallBlock.Forward))
-	        {
-		        Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, 0, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, 0.5f) + offset);
-		        Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, 0, 0.5f) + offset);
-	        }
+            if (Convert.ToBoolean(asset.WallSettings & (int)WallBlock.Forward))
+            {
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, 0, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, 0.5f) + offset);
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, 0, 0.5f) + offset);
+            }
 
-	        if (Convert.ToBoolean(asset.WallSettings & (int) WallBlock.Back))
-			{
-				Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, 0, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, -0.5f) + offset);
-				Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, 0, -0.5f) + offset);
-			}
+            if (Convert.ToBoolean(asset.WallSettings & (int)WallBlock.Back))
+            {
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, 0, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, -0.5f) + offset);
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, 0, -0.5f) + offset);
+            }
 
-	        if (Convert.ToBoolean(asset.WallSettings & (int) WallBlock.Left))
-	        {
-		        Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, 0, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, 0.5f) + offset);
-		        Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, 0, 0.5f) + offset);
-	        }
+            if (Convert.ToBoolean(asset.WallSettings & (int)WallBlock.Left))
+            {
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, 0, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, 0.5f) + offset);
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(-0.5f, asset.Height, -0.5f) + offset, asset.GameObject.transform.position + new Vector3(-0.5f, 0, 0.5f) + offset);
+            }
 
-	        if (Convert.ToBoolean(asset.WallSettings & (int) WallBlock.Right))
-			{
-				Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, 0, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, -0.5f) + offset);
-				Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, 0, -0.5f) + offset);
-			}
+            if (Convert.ToBoolean(asset.WallSettings & (int)WallBlock.Right))
+            {
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, 0, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, -0.5f) + offset);
+                Gizmos.DrawLine(asset.GameObject.transform.position + new Vector3(0.5f, asset.Height, 0.5f) + offset, asset.GameObject.transform.position + new Vector3(0.5f, 0, -0.5f) + offset);
+            }
         }
     }
 }

--- a/Assets/Editor/GizmoRenderers/WaypointRenderer.cs
+++ b/Assets/Editor/GizmoRenderers/WaypointRenderer.cs
@@ -4,223 +4,223 @@ using UnityEngine.Rendering;
 
 namespace ParkitectAssetEditor.GizmoRenderers
 {
-	public class WaypointRenderer : IGizmoRenderer, IHandleRenderer
-	{
-		public enum WaypointState
-		{
-			NONE,
-			CONNECT
-		}
+    public class WaypointRenderer : IGizmoRenderer, IHandleRenderer
+    {
+        public enum WaypointState
+        {
+            NONE,
+            CONNECT
+        }
 
-		private bool _snapToPlane = false;
+        private bool _snapToPlane = false;
 
-		public bool CanRender(Asset asset)
-		{
-			return asset.Type == AssetType.FlatRide;
-		}
+        public bool CanRender(Asset asset)
+        {
+            return asset.Type == AssetType.FlatRide;
+        }
 
-		public void Render(Asset asset)
-		{
+        public void Render(Asset asset)
+        {
 
-		}
+        }
 
-		public void Handle(Asset asset)
-		{
+        public void Handle(Asset asset)
+        {
 
-			if (asset.EnableWaypointEditing)
-			{
-				if (_snapToPlane && asset.SelectedWaypoint != null)
-				{
-					asset.SelectedWaypoint.Position.y = asset.HelperPlaneY;
-				}
+            if (asset.EnableWaypointEditing)
+            {
+                if (_snapToPlane && asset.SelectedWaypoint != null)
+                {
+                    asset.SelectedWaypoint.Position.y = asset.HelperPlaneY;
+                }
 
-				switch (Event.current.type)
-				{
-					case EventType.Layout:
-						break;
-					case EventType.KeyDown:
-						if (Event.current.keyCode == KeyCode.LeftControl)
-						{
-							_snapToPlane = true;
-						}
+                switch (Event.current.type)
+                {
+                    case EventType.Layout:
+                        break;
+                    case EventType.KeyDown:
+                        if (Event.current.keyCode == KeyCode.LeftControl)
+                        {
+                            _snapToPlane = true;
+                        }
 
-						break;
-					case EventType.KeyUp:
-						if (Event.current.keyCode == KeyCode.C)
-						{
-							if (asset.WaypointState != WaypointState.CONNECT)
-							{
-								asset.WaypointState = WaypointState.CONNECT;
-							}
-							else
-							{
-								asset.WaypointState = WaypointState.NONE;
-							}
-						}
+                        break;
+                    case EventType.KeyUp:
+                        if (Event.current.keyCode == KeyCode.C)
+                        {
+                            if (asset.WaypointState != WaypointState.CONNECT)
+                            {
+                                asset.WaypointState = WaypointState.CONNECT;
+                            }
+                            else
+                            {
+                                asset.WaypointState = WaypointState.NONE;
+                            }
+                        }
 
-						if (Event.current.keyCode == KeyCode.R && asset.SelectedWaypoint != null)
-						{
-							if (asset.SelectedWaypoint == null)
-							{
-								break;
-							}
+                        if (Event.current.keyCode == KeyCode.R && asset.SelectedWaypoint != null)
+                        {
+                            if (asset.SelectedWaypoint == null)
+                            {
+                                break;
+                            }
 
-							Waypoint.DeletePoint(asset, asset.SelectedWaypoint);
-						}
+                            Waypoint.DeletePoint(asset, asset.SelectedWaypoint);
+                        }
 
-						if (Event.current.keyCode == KeyCode.A)
-						{
-							Ray ray = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
+                        if (Event.current.keyCode == KeyCode.A)
+                        {
+                            Ray ray = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
 
-							Vector3 hitPosition = Vector3.zero;
+                            Vector3 hitPosition = Vector3.zero;
                             EditorHandles_UnityInternal.SceneRaycastHit hit;
-							if (EditorHandles_UnityInternal.IntersectRayGameObject(ray, asset.GameObject, out hit))
-							{
-								hitPosition = hit.point;
-							}
-							else
-							{
-								Plane plane = new Plane(Vector3.up, new Vector3(0, asset.HelperPlaneY, 0));
-								float enter = 0;
-								plane.Raycast(ray, out enter);
-								hitPosition = ray.GetPoint(enter);
-							}
+                            if (EditorHandles_UnityInternal.IntersectRayGameObject(ray, asset.GameObject, out hit))
+                            {
+                                hitPosition = hit.point;
+                            }
+                            else
+                            {
+                                Plane plane = new Plane(Vector3.up, new Vector3(0, asset.HelperPlaneY, 0));
+                                float enter = 0;
+                                plane.Raycast(ray, out enter);
+                                hitPosition = ray.GetPoint(enter);
+                            }
 
-							asset.SelectedWaypoint = Waypoint.addWaypoint(asset, hitPosition);
-						}
+                            asset.SelectedWaypoint = Waypoint.addWaypoint(asset, hitPosition);
+                        }
 
-						if (Event.current.keyCode == KeyCode.O && asset.SelectedWaypoint != null)
-						{
-							asset.SelectedWaypoint.IsOuter = !asset.SelectedWaypoint.IsOuter;
-						}
+                        if (Event.current.keyCode == KeyCode.O && asset.SelectedWaypoint != null)
+                        {
+                            asset.SelectedWaypoint.IsOuter = !asset.SelectedWaypoint.IsOuter;
+                        }
 
-						if (Event.current.keyCode == KeyCode.I && asset.SelectedWaypoint != null)
-						{
-							asset.SelectedWaypoint.IsRabbitHoleGoal = !asset.SelectedWaypoint.IsRabbitHoleGoal;
-						}
+                        if (Event.current.keyCode == KeyCode.I && asset.SelectedWaypoint != null)
+                        {
+                            asset.SelectedWaypoint.IsRabbitHoleGoal = !asset.SelectedWaypoint.IsRabbitHoleGoal;
+                        }
 
-						if (Event.current.keyCode == KeyCode.LeftControl)
-						{
-							_snapToPlane = false;
-						}
+                        if (Event.current.keyCode == KeyCode.LeftControl)
+                        {
+                            _snapToPlane = false;
+                        }
 
-						SceneView.RepaintAll();
-						HandleUtility.Repaint();
-						break;
-				}
+                        SceneView.RepaintAll();
+                        HandleUtility.Repaint();
+                        break;
+                }
 
-				//render helper plane
-				Vector3 topLeft = new Vector3(-((float) asset.FootprintX) / 2.0f, 0, (float) asset.FootprintZ / 2.0f) +
-								  asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
-				Vector3 topRight = new Vector3(((float) asset.FootprintX) / 2.0f, 0, (float) asset.FootprintZ / 2.0f) +
-								   asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
-				Vector3 bottomLeft =
-					new Vector3(-((float) asset.FootprintX) / 2.0f, 0, -(float) asset.FootprintZ / 2.0f) +
-					asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
-				Vector3 bottomRight =
-					new Vector3(((float) asset.FootprintX) / 2.0f, 0, -(float) asset.FootprintZ / 2.0f) +
-					asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
+                //render helper plane
+                Vector3 topLeft = new Vector3(-((float)asset.FootprintX) / 2.0f, 0, (float)asset.FootprintZ / 2.0f) +
+                                  asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
+                Vector3 topRight = new Vector3(((float)asset.FootprintX) / 2.0f, 0, (float)asset.FootprintZ / 2.0f) +
+                                   asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
+                Vector3 bottomLeft =
+                    new Vector3(-((float)asset.FootprintX) / 2.0f, 0, -(float)asset.FootprintZ / 2.0f) +
+                    asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
+                Vector3 bottomRight =
+                    new Vector3(((float)asset.FootprintX) / 2.0f, 0, -(float)asset.FootprintZ / 2.0f) +
+                    asset.GameObject.transform.position + new Vector3(0, asset.HelperPlaneY, 0);
 
-				Color fill = Color.white;
-				fill.a = 0.1f;
-				Handles.zTest = CompareFunction.LessEqual;
-				Handles.color = Color.yellow;
-				Handles.DrawSolidRectangleWithOutline(new[] {topLeft, topRight, bottomRight, bottomLeft}, fill,
-					Color.black);
-				Handles.zTest = CompareFunction.Always;
-			}
+                Color fill = Color.white;
+                fill.a = 0.1f;
+                Handles.zTest = CompareFunction.LessEqual;
+                Handles.color = Color.yellow;
+                Handles.DrawSolidRectangleWithOutline(new[] { topLeft, topRight, bottomRight, bottomLeft }, fill,
+                    Color.black);
+                Handles.zTest = CompareFunction.Always;
+            }
 
-			for (int x = 0; x < asset.Waypoints.Count; x++)
-			{
-				if (asset.EnableWaypointEditing && asset.Waypoints[x] == asset.SelectedWaypoint)
-				{
-					Handles.color = Color.red;
-				}
-				else if (asset.Waypoints[x].IsOuter)
-				{
-					Handles.color = Color.green;
-				}
-				else if (asset.Waypoints[x].IsRabbitHoleGoal)
-				{
-					Handles.color = Color.blue;
-				}
-				else
-				{
-					Handles.color = Color.yellow;
-				}
+            for (int x = 0; x < asset.Waypoints.Count; x++)
+            {
+                if (asset.EnableWaypointEditing && asset.Waypoints[x] == asset.SelectedWaypoint)
+                {
+                    Handles.color = Color.red;
+                }
+                else if (asset.Waypoints[x].IsOuter)
+                {
+                    Handles.color = Color.green;
+                }
+                else if (asset.Waypoints[x].IsRabbitHoleGoal)
+                {
+                    Handles.color = Color.blue;
+                }
+                else
+                {
+                    Handles.color = Color.yellow;
+                }
 
-				Vector3 worldPos = asset.Waypoints[x].Position + asset.GameObject.transform.position;
+                Vector3 worldPos = asset.Waypoints[x].Position + asset.GameObject.transform.position;
 
-				Handles.zTest = CompareFunction.LessEqual;
-				
-				if (Handles.Button(worldPos, Quaternion.identity, HandleUtility.GetHandleSize(worldPos) * 0.2f,
-					HandleUtility.GetHandleSize(worldPos) * 0.2f, Handles.SphereHandleCap))
-				{
-					if (asset.EnableWaypointEditing)
-					{
-						handleClick(asset, asset.Waypoints[x]);
-					}
-				}
+                Handles.zTest = CompareFunction.LessEqual;
 
-				Handles.color = Color.blue;
-				foreach (int connectedIndex in asset.Waypoints[x].ConnectedTo)
-				{
-					Handles.DrawLine(worldPos,
-						asset.Waypoints[connectedIndex].Position + asset.GameObject.transform.position);
-				}
-				Handles.color = Color.white;
-				Handles.Label(worldPos, "#" + x);
+                if (Handles.Button(worldPos, Quaternion.identity, HandleUtility.GetHandleSize(worldPos) * 0.2f,
+                    HandleUtility.GetHandleSize(worldPos) * 0.2f, Handles.SphereHandleCap))
+                {
+                    if (asset.EnableWaypointEditing)
+                    {
+                        handleClick(asset, asset.Waypoints[x]);
+                    }
+                }
 
-				Handles.zTest = CompareFunction.Always;
-			}
+                Handles.color = Color.blue;
+                foreach (int connectedIndex in asset.Waypoints[x].ConnectedTo)
+                {
+                    Handles.DrawLine(worldPos,
+                        asset.Waypoints[connectedIndex].Position + asset.GameObject.transform.position);
+                }
+                Handles.color = Color.white;
+                Handles.Label(worldPos, "#" + x);
 
-			if (asset.EnableWaypointEditing && asset.SelectedWaypoint != null)
-			{
-				Vector3 worldPos = asset.SelectedWaypoint.Position + asset.GameObject.transform.position;
+                Handles.zTest = CompareFunction.Always;
+            }
 
-				if (asset.WaypointState == WaypointState.CONNECT)
-				{
-					Handles.Label(worldPos, "\nConnecting...");
-				}
-				else
-				{
-					asset.SelectedWaypoint.Position = asset.GameObject.transform.InverseTransformPoint(
-						Handles.PositionHandle(
-							asset.GameObject.transform.TransformPoint(asset.SelectedWaypoint.Position),
-							Quaternion.identity));
-					Handles.Label(worldPos, "\n(A)dd\n(C)onnect\n(R)emove\n(O)uter\nRabb(i)t Hole");
-				}
-			}
-		}
+            if (asset.EnableWaypointEditing && asset.SelectedWaypoint != null)
+            {
+                Vector3 worldPos = asset.SelectedWaypoint.Position + asset.GameObject.transform.position;
 
-		private void handleClick(Asset asset, Waypoint waypoint)
-		{
-			if (asset.WaypointState == WaypointState.NONE && waypoint != null)
-			{
-				asset.SelectedWaypoint = waypoint;
-			}
-			else if (asset.WaypointState == WaypointState.CONNECT && waypoint != null)
-			{
-				int closestWaypointIndex = asset.Waypoints.FindIndex(delegate(Waypoint wp) { return wp == waypoint; });
-				int selectedWaypointIndex = asset.Waypoints.FindIndex(delegate(Waypoint wp)
-				{
-					return wp == asset.SelectedWaypoint;
-				});
-				if (closestWaypointIndex >= 0 && selectedWaypointIndex >= 0)
-				{
-					if (!asset.SelectedWaypoint.ConnectedTo.Contains(closestWaypointIndex))
-					{
-						asset.SelectedWaypoint.ConnectedTo.Add(closestWaypointIndex);
-						waypoint.ConnectedTo.Add(selectedWaypointIndex);
-					}
-					else
-					{
-						asset.SelectedWaypoint.ConnectedTo.Remove(closestWaypointIndex);
-						waypoint.ConnectedTo.Remove(selectedWaypointIndex);
-					}
-				}
-			}
-		}
+                if (asset.WaypointState == WaypointState.CONNECT)
+                {
+                    Handles.Label(worldPos, "\nConnecting...");
+                }
+                else
+                {
+                    asset.SelectedWaypoint.Position = asset.GameObject.transform.InverseTransformPoint(
+                        Handles.PositionHandle(
+                            asset.GameObject.transform.TransformPoint(asset.SelectedWaypoint.Position),
+                            Quaternion.identity));
+                    Handles.Label(worldPos, "\n(A)dd\n(C)onnect\n(R)emove\n(O)uter\nRabb(i)t Hole");
+                }
+            }
+        }
 
-	}
+        private void handleClick(Asset asset, Waypoint waypoint)
+        {
+            if (asset.WaypointState == WaypointState.NONE && waypoint != null)
+            {
+                asset.SelectedWaypoint = waypoint;
+            }
+            else if (asset.WaypointState == WaypointState.CONNECT && waypoint != null)
+            {
+                int closestWaypointIndex = asset.Waypoints.FindIndex(delegate (Waypoint wp) { return wp == waypoint; });
+                int selectedWaypointIndex = asset.Waypoints.FindIndex(delegate (Waypoint wp)
+                {
+                    return wp == asset.SelectedWaypoint;
+                });
+                if (closestWaypointIndex >= 0 && selectedWaypointIndex >= 0)
+                {
+                    if (!asset.SelectedWaypoint.ConnectedTo.Contains(closestWaypointIndex))
+                    {
+                        asset.SelectedWaypoint.ConnectedTo.Add(closestWaypointIndex);
+                        waypoint.ConnectedTo.Add(selectedWaypointIndex);
+                    }
+                    else
+                    {
+                        asset.SelectedWaypoint.ConnectedTo.Remove(closestWaypointIndex);
+                        waypoint.ConnectedTo.Remove(selectedWaypointIndex);
+                    }
+                }
+            }
+        }
+
+    }
 }

--- a/Assets/Editor/ProjectManager.cs
+++ b/Assets/Editor/ProjectManager.cs
@@ -46,7 +46,7 @@ namespace ParkitectAssetEditor
         }
 
         private static string _autoSaveHash = "";
-        
+
         /// <summary>
         /// Saves the project.
         /// </summary>
@@ -63,7 +63,7 @@ namespace ParkitectAssetEditor
                 Debug.Log("There are no defined assets in the Asset Pack, can't save");
                 return false;
             }
-            
+
             string output = JsonConvert.SerializeObject(AssetPack);
 
             File.WriteAllText(path, output);
@@ -80,7 +80,7 @@ namespace ParkitectAssetEditor
         public static bool Export(bool exportAssetZip)
         {
             AssetPack.BuildGuid = GUID.Generate().ToString();
-            
+
             EditorSceneManager.SaveScene(SceneManager.GetActiveScene());
 
             var path = Path.Combine(Project.Value.ProjectDirectory, Project.Value.ProjectFile);
@@ -96,7 +96,7 @@ namespace ParkitectAssetEditor
                 {
                     File.Delete(assetZipPath);
                 }
-                
+
                 if (exportAssetZip)
                 {
                     Debug.Log(string.Format("Archiving {0} to {1}", Project.Value.ProjectDirectory, assetZipPath));
@@ -111,7 +111,7 @@ namespace ParkitectAssetEditor
             }
 
             Debug.LogWarning(string.Format("Failed saving project {0}", path));
-            
+
             return false;
         }
 
@@ -136,9 +136,9 @@ namespace ParkitectAssetEditor
                 ProjectFile = Path.GetFileName(path),
                 ProjectFileAutoSave = Path.GetFileName(path) + ".autosave"
             };
-            
+
             AssetPack = JsonConvert.DeserializeObject<AssetPack>(File.ReadAllText(path));
-            
+
             AssetPack.LoadGameObjects();
             AssetPack.InitAssetsInScene();
 
@@ -159,7 +159,7 @@ namespace ParkitectAssetEditor
         public static void AutoSave()
         {
             var path = EditorPrefs.GetString("loadedProject");
-            
+
             string output = JsonConvert.SerializeObject(AssetPack);
 
             using (var md5 = MD5.Create())
@@ -189,7 +189,7 @@ namespace ParkitectAssetEditor
         public static void AutoLoad()
         {
             var path = EditorPrefs.GetString("loadedProject");
-            
+
             // .autosave = 9 characters, them hacks!
             var pathWithoutAutoSave = path.Remove(path.Length - 9);
 
@@ -203,7 +203,7 @@ namespace ParkitectAssetEditor
                 ProjectFile = Path.GetFileName(pathWithoutAutoSave),
                 ProjectFileAutoSave = Path.GetFileName(pathWithoutAutoSave) + ".autosave"
             };
-            
+
             AssetPack = JsonConvert.DeserializeObject<AssetPack>(File.ReadAllText(path));
 
             EditorPrefs.SetString("loadedProject", Path.Combine(Project.Value.ProjectDirectory, Project.Value.ProjectFileAutoSave));
@@ -246,7 +246,7 @@ namespace ParkitectAssetEditor
             {
                 throw new ProjectAlreadyExistsException(string.Format("There already is a project at {0}", projectFilePath));
             }
-            
+
             if (Directory.Exists(modDirectory))
             {
                 throw new ProjectAlreadyExistsException(string.Format("Your Parkitect installation already has a mod called {0} at {1}", name, modDirectory));
@@ -264,7 +264,7 @@ namespace ParkitectAssetEditor
             AssetPack = new AssetPack
             {
                 Name = name,
-				Description = "An asset pack"
+                Description = "An asset pack"
             };
 
             EditorPrefs.SetString("loadedProject", Path.Combine(Project.Value.ProjectDirectory, Project.Value.ProjectFileAutoSave));

--- a/Assets/Editor/ProjectManager.cs
+++ b/Assets/Editor/ProjectManager.cs
@@ -16,7 +16,7 @@ namespace ParkitectAssetEditor
     /// <summary>
     /// Class for saving/loading projects.
     /// </summary>
-    static class ProjectManager
+    internal static class ProjectManager
     {
         /// <summary>
         /// Gets the loaded project.

--- a/Assets/Editor/ProjectManager.cs
+++ b/Assets/Editor/ProjectManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -7,7 +6,6 @@ using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using ParkitectAssetEditor.Compression;
 using ParkitectAssetEditor.UI;
-using ParkitectAssetEditor.Utility;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;

--- a/Assets/Editor/UI/AssetEditorWindow.cs
+++ b/Assets/Editor/UI/AssetEditorWindow.cs
@@ -95,7 +95,7 @@ namespace ParkitectAssetEditor.UI
 			GetWindow(typeof(AssetEditorWindow));
 		}
 
-		void Awake()
+		private void Awake()
 		{
 			// Make sure it doesn't autoload the project on unity start. This editor pref is just for when unity loses its state when it compiles.
 			EditorPrefs.SetString("loadedProject", null);
@@ -164,7 +164,7 @@ namespace ParkitectAssetEditor.UI
 		}
 
 		[DrawGizmo(GizmoType.Selected)]
-		static void DrawGizmoForMyScript(Transform scr, GizmoType gizmoType)
+		private static void DrawGizmoForMyScript(Transform scr, GizmoType gizmoType)
 		{
 			if (ProjectManager.AssetPack == null)
 			{
@@ -183,7 +183,7 @@ namespace ParkitectAssetEditor.UI
 			}
 		}
 		
-		void OnFocus()
+		private void OnFocus()
 		{
 			// Remove delegate listener if it has previously
 			// been assigned.
@@ -192,7 +192,7 @@ namespace ParkitectAssetEditor.UI
 			SceneView.onSceneGUIDelegate += OnSceneGUI;
 		}
 
-		void OnDestroy()
+		private void OnDestroy()
 		{
 			// When the window is destroyed, remove the delegate
 			// so that it will no longer do any drawing.
@@ -201,7 +201,7 @@ namespace ParkitectAssetEditor.UI
 
 		}
 
-		void OnSceneGUI(SceneView sceneView)
+        private void OnSceneGUI(SceneView sceneView)
 		{
 			if (ProjectManager.AssetPack == null)
 			{

--- a/Assets/Editor/UI/AssetEditorWindow.cs
+++ b/Assets/Editor/UI/AssetEditorWindow.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using ParkitectAssetEditor.GizmoRenderers;
 using ParkitectAssetEditor.Utility;
 using UnityEditor;
-using UnityEditor.Animations;
 using UnityEngine;
 
 namespace ParkitectAssetEditor.UI

--- a/Assets/Editor/UI/AssetEditorWindow.cs
+++ b/Assets/Editor/UI/AssetEditorWindow.cs
@@ -9,942 +9,950 @@ using UnityEngine;
 
 namespace ParkitectAssetEditor.UI
 {
-	/// <inheritdoc />
-	/// <summary>
-	/// The main asset editor window.
-	/// </summary>
-	/// <seealso cref="T:UnityEditor.EditorWindow" />
-	public class AssetEditorWindow : EditorWindow
-	{
-		/// <summary>
-		/// The window scroll position.
-		/// </summary>
-		private Vector2 _windowScrollPosition;
+    /// <inheritdoc />
+    /// <summary>
+    /// The main asset editor window.
+    /// </summary>
+    /// <seealso cref="T:UnityEditor.EditorWindow" />
+    public class AssetEditorWindow : EditorWindow
+    {
+        /// <summary>
+        /// The window scroll position.
+        /// </summary>
+        private Vector2 _windowScrollPosition;
 
-		/// <summary>
-		/// The asset list scroll position.
-		/// </summary>
-		private Vector2 _assetListScrollPos;
+        /// <summary>
+        /// The asset list scroll position.
+        /// </summary>
+        private Vector2 _assetListScrollPos;
 
-		private Vector2 _descriptionTextScrollPosition;
+        private Vector2 _descriptionTextScrollPosition;
 
-		/// <summary>
-		/// The selected asset.
-		/// </summary>
-		private Asset _selectedAsset;
-	   
+        /// <summary>
+        /// The selected asset.
+        /// </summary>
+        private Asset _selectedAsset;
 
-		private static readonly IGizmoRenderer[] _gizmoRenderers = {
-			new SeatRenderer(),
-			new WallRenderer(),
-			new GridRenderer(), 
-			new SignRenderer(), 
-			new FootprintRenderer(),
-			new WaypointRenderer(), 
-			new BoundingBoxRenderer(), 
-			new TrainRenderer(), 
-		};
 
-		private static string[] trackedRideNames = new[]
-		{
-			"Alpine Coaster",
-			"Boat Dark Ride",
-			"Boat Transport",
-			"Calm River Ride",
-			"Car Ride",
-			"Floorless Coaster",
-			"Flying Coaster",
-			"Gentle Monorail Ride",
-			"Ghost Mansion Ride",
-			"Giga Coaster",
-			"Hydraulically-Launched Coaster",
-			"Hyper Coaster",
-			"Inverted Coaster",
-			"Inverted Dark Ride",
-			"Inverting Spinning Coaster",
-			"Inverting Wooden Coaster",
-			"Junior Coaster",
-			"Log Flume",
-			"Mine Train Coaster",
-			"Miniature Railway",
-			"Mini Coaster",
-			"Mini Monorail",
-			"Monorail",
-			"Monorail Coaster",
-			"Pivot Coaster",
-			"Powered Coaster",
-			"Spinning Coaster",
-			"Splash Battle",
-			"Stand-up Coaster",
-			"Steel Coaster",
-			"Steeplechase",
-			"Submarines",
-			"Suspended Coaster",
-			"Suspended Monorail",
-			"Tilt Coaster",
-			"Vertical Drop Coaster",
-			"Water Coaster",
-			"Wild Mouse",
-			"Wing Coaster",
-			"Wooden Coaster",
-		};
+        private static readonly IGizmoRenderer[] _gizmoRenderers = {
+            new SeatRenderer(),
+            new WallRenderer(),
+            new GridRenderer(),
+            new SignRenderer(),
+            new FootprintRenderer(),
+            new WaypointRenderer(),
+            new BoundingBoxRenderer(),
+            new TrainRenderer(),
+        };
 
-		[MenuItem("Window/Parkitect Asset Editor")]
-		public static void ShowWindow()
-		{
-			GetWindow(typeof(AssetEditorWindow));
-		}
+        private static string[] trackedRideNames = new[]
+        {
+            "Alpine Coaster",
+            "Boat Dark Ride",
+            "Boat Transport",
+            "Calm River Ride",
+            "Car Ride",
+            "Floorless Coaster",
+            "Flying Coaster",
+            "Gentle Monorail Ride",
+            "Ghost Mansion Ride",
+            "Giga Coaster",
+            "Hydraulically-Launched Coaster",
+            "Hyper Coaster",
+            "Inverted Coaster",
+            "Inverted Dark Ride",
+            "Inverting Spinning Coaster",
+            "Inverting Wooden Coaster",
+            "Junior Coaster",
+            "Log Flume",
+            "Mine Train Coaster",
+            "Miniature Railway",
+            "Mini Coaster",
+            "Mini Monorail",
+            "Monorail",
+            "Monorail Coaster",
+            "Pivot Coaster",
+            "Powered Coaster",
+            "Spinning Coaster",
+            "Splash Battle",
+            "Stand-up Coaster",
+            "Steel Coaster",
+            "Steeplechase",
+            "Submarines",
+            "Suspended Coaster",
+            "Suspended Monorail",
+            "Tilt Coaster",
+            "Vertical Drop Coaster",
+            "Water Coaster",
+            "Wild Mouse",
+            "Wing Coaster",
+            "Wooden Coaster",
+        };
 
-		private void Awake()
-		{
-			// Make sure it doesn't autoload the project on unity start. This editor pref is just for when unity loses its state when it compiles.
-			EditorPrefs.SetString("loadedProject", null);
+        [MenuItem("Window/Parkitect Asset Editor")]
+        public static void ShowWindow()
+        {
+            GetWindow(typeof(AssetEditorWindow));
+        }
 
-			var files = Directory.GetFiles(Application.dataPath, "*.assetProject");
-			
-			if (files.Length > 0)
-			{
-				ProjectManager.Load(files[0]);
-			}
-		}
-		
-		public void Update()
-		{
-			// Unity loses its state when it compiles, with the editor pref we can load the opened project automatically.
-			if (!ProjectManager.Initialized && !string.IsNullOrEmpty(EditorPrefs.GetString("loadedProject")))
-			{
-				ProjectManager.AutoLoad();
+        private void Awake()
+        {
+            // Make sure it doesn't autoload the project on unity start. This editor pref is just for when unity loses its state when it compiles.
+            EditorPrefs.SetString("loadedProject", null);
 
-				_selectedAsset = ProjectManager.AssetPack.Assets.First();
-			}
+            var files = Directory.GetFiles(Application.dataPath, "*.assetProject");
 
-			if (ProjectManager.Initialized)
-			{
-				ProjectManager.AutoSave();
+            if (files.Length > 0)
+            {
+                ProjectManager.Load(files[0]);
+            }
+        }
 
-				// sync the selected game object in the scene with the corresponding asset
-				if (_selectedAsset != null && Selection.activeGameObject != _selectedAsset.GameObject)
-				{
-					var asset = ProjectManager.AssetPack.Assets.FirstOrDefault(a => a.GameObject == Selection.activeGameObject);
+        public void Update()
+        {
+            // Unity loses its state when it compiles, with the editor pref we can load the opened project automatically.
+            if (!ProjectManager.Initialized && !string.IsNullOrEmpty(EditorPrefs.GetString("loadedProject")))
+            {
+                ProjectManager.AutoLoad();
 
-					if (asset != null)
-					{
-						_selectedAsset = asset;
+                _selectedAsset = ProjectManager.AssetPack.Assets.First();
+            }
 
-						Repaint();
-					}
-				}
-			}
-		}
+            if (ProjectManager.Initialized)
+            {
+                ProjectManager.AutoSave();
 
-		public void OnGUI()
-		{
-			if (!ProjectManager.Initialized)
-			{
-				EditorGUILayout.HelpBox("Create a project first", MessageType.Info);
+                // sync the selected game object in the scene with the corresponding asset
+                if (_selectedAsset != null && Selection.activeGameObject != _selectedAsset.GameObject)
+                {
+                    var asset = ProjectManager.AssetPack.Assets.FirstOrDefault(a => a.GameObject == Selection.activeGameObject);
 
-				if (GUILayout.Button("New project"))
-				{
-					NewProjectWindow.Show();
-				}
+                    if (asset != null)
+                    {
+                        _selectedAsset = asset;
 
-				return;
-			}
+                        Repaint();
+                    }
+                }
+            }
+        }
 
-			// This draws the whole asset editor window, split up in sections.
-			GUILayout.BeginVertical();
-			_windowScrollPosition = GUILayout.BeginScrollView(_windowScrollPosition);
-			DrawAssetPackSettingsSection();
-			GUILayout.Space(15);
-			DrawAssetListSection();
-			GUILayout.Space(15);
-			DrawAssetDetailSection();
-			GUILayout.EndScrollView();
-			GUILayout.EndVertical();
-		}
+        public void OnGUI()
+        {
+            if (!ProjectManager.Initialized)
+            {
+                EditorGUILayout.HelpBox("Create a project first", MessageType.Info);
 
-		[DrawGizmo(GizmoType.Selected)]
-		private static void DrawGizmoForMyScript(Transform scr, GizmoType gizmoType)
-		{
-			if (ProjectManager.AssetPack == null)
-			{
-				return;
-			}
+                if (GUILayout.Button("New project"))
+                {
+                    NewProjectWindow.Show();
+                }
 
-			foreach (var asset in ProjectManager.AssetPack.Assets.Where(a => a.GameObject != null && scr.GetComponentsInParent<Transform>().Contains(a.GameObject.transform)))
-			{
-				foreach (var gizmoRenderer in _gizmoRenderers)
-				{
-					if (gizmoRenderer.CanRender(asset))
-					{
-						gizmoRenderer.Render(asset);
-					}
-				}
-			}
-		}
-		
-		private void OnFocus()
-		{
-			// Remove delegate listener if it has previously
-			// been assigned.
-			SceneView.onSceneGUIDelegate -= OnSceneGUI;
-			// Add (or re-add) the delegate.
-			SceneView.onSceneGUIDelegate += OnSceneGUI;
-		}
+                return;
+            }
 
-		private void OnDestroy()
-		{
-			// When the window is destroyed, remove the delegate
-			// so that it will no longer do any drawing.
-			//Exporter.SaveToXML(ModManager);
-			SceneView.onSceneGUIDelegate -= OnSceneGUI;
+            // This draws the whole asset editor window, split up in sections.
+            GUILayout.BeginVertical();
+            _windowScrollPosition = GUILayout.BeginScrollView(_windowScrollPosition);
+            DrawAssetPackSettingsSection();
+            GUILayout.Space(15);
+            DrawAssetListSection();
+            GUILayout.Space(15);
+            DrawAssetDetailSection();
+            GUILayout.EndScrollView();
+            GUILayout.EndVertical();
+        }
 
-		}
+        [DrawGizmo(GizmoType.Selected)]
+        private static void DrawGizmoForMyScript(Transform scr, GizmoType gizmoType)
+        {
+            if (ProjectManager.AssetPack == null)
+            {
+                return;
+            }
+
+            foreach (var asset in ProjectManager.AssetPack.Assets.Where(a => a.GameObject != null && scr.GetComponentsInParent<Transform>().Contains(a.GameObject.transform)))
+            {
+                foreach (var gizmoRenderer in _gizmoRenderers)
+                {
+                    if (gizmoRenderer.CanRender(asset))
+                    {
+                        gizmoRenderer.Render(asset);
+                    }
+                }
+            }
+        }
+
+        private void OnFocus()
+        {
+            // Remove delegate listener if it has previously
+            // been assigned.
+            SceneView.onSceneGUIDelegate -= OnSceneGUI;
+            // Add (or re-add) the delegate.
+            SceneView.onSceneGUIDelegate += OnSceneGUI;
+        }
+
+        private void OnDestroy()
+        {
+            // When the window is destroyed, remove the delegate
+            // so that it will no longer do any drawing.
+            //Exporter.SaveToXML(ModManager);
+            SceneView.onSceneGUIDelegate -= OnSceneGUI;
+
+        }
 
         private void OnSceneGUI(SceneView sceneView)
-		{
-			if (ProjectManager.AssetPack == null)
-			{
-				return;
-			}
-
-			if (_selectedAsset == null)
-			{
-				return;
-			}
-
-			foreach (var gizmoRenderer in _gizmoRenderers)
-			{
-				if (gizmoRenderer.CanRender(_selectedAsset))
-				{
-					var renderer = gizmoRenderer as IHandleRenderer;
-					if (renderer != null)
-					{
-						renderer.Handle(_selectedAsset);
-					}
-				}
-			}
-		}
-
-		/// <summary>
-		/// Draws the asset pack settings section.
-		/// </summary>
-		private void DrawAssetPackSettingsSection()
-		{
-			GUILayout.Label("Asset Pack Settings", "PreToolbar");
-
-			ProjectManager.AssetPack.Name = EditorGUILayout.TextField("Name", ProjectManager.AssetPack.Name);
-			GUILayout.Label("Pack description", EditorStyles.boldLabel);
-			_descriptionTextScrollPosition = EditorGUILayout.BeginScrollView(_descriptionTextScrollPosition, GUILayout.Height(150));
-			ProjectManager.AssetPack.Description = EditorGUILayout.TextArea(ProjectManager.AssetPack.Description, GUILayout.ExpandHeight(true));
-			EditorGUILayout.EndScrollView();
-			ProjectManager.AssetPack.OrderPriority = EditorGUILayout.IntField("Load Order Priority", ProjectManager.AssetPack.OrderPriority);
-			
-			GUILayout.Label("Assemblies", EditorStyles.boldLabel);
-			//adds a waypoint at (0,0,0) relative to the unity object
-			if (GUILayout.Button("Add Assembly"))
-			{
-				ProjectManager.AssetPack.Assemblies.Add("");
-			}
-
-			//provides a list of all the waypoints
-			for (int i = 0; i < ProjectManager.AssetPack.Assemblies.Count; i++)
-			{
-				EditorGUILayout.BeginHorizontal();
-				GUILayout.Label("#" + i);
-
-				ProjectManager.AssetPack.Assemblies[i] = EditorGUILayout.TextField(ProjectManager.AssetPack.Assemblies[i]);
-
-				if (GUILayout.Button("Delete"))
-				{
-					ProjectManager.AssetPack.Assemblies.RemoveAt(i);
-					i--;
-				}
-
-				EditorGUILayout.EndHorizontal();
-			}
-
-			EditorGUILayout.Space();
-
-			EditorGUILayout.HelpBox("Stores your raw model files with the asset pack in an archive. Recommended: on", MessageType.Info);
-			ProjectManager.AssetPack.ArchiveAssets = EditorGUILayout.Toggle("Archive assets", ProjectManager.AssetPack.ArchiveAssets);
-			
-			ProjectManager.AssetPack.VersionNumber = EditorGUILayout.TextField("Version number", ProjectManager.AssetPack.VersionNumber);
-
-			GUILayout.Space(10);
-
-			if (GUILayout.Button("Export Asset Pack"))
-			{
-				ProjectManager.Export(ProjectManager.AssetPack.ArchiveAssets);
-			}
-		}
-
-		/// <summary>
-		/// Draws the asset list section.
-		/// </summary>
-		private void DrawAssetListSection()
-		{
-			GUILayout.Label("Assets", "PreToolbar");
-
-			EditorGUILayout.HelpBox("Drag your GameObject to this field to start editing.", MessageType.Info);
-
-			// Game object drop box
-			var newAsset = EditorGUILayout.ObjectField("Drop to add:", null, typeof(GameObject), true) as GameObject;
-			if (newAsset != null && newAsset.scene.name != null) // scene name is null for prefabs, yay for unity for checking it this way
-			{
-				SelectAsset(ProjectManager.AssetPack.Add(newAsset));
-			}
-
-			// Asset list
-			_assetListScrollPos = EditorGUILayout.BeginScrollView(_assetListScrollPos, "GroupBox", GUILayout.Height(200));
-			foreach (var asset in ProjectManager.AssetPack.Assets)
-			{
-				// blue button for selected asset, black for non selected
-				var style = new GUIStyle(GUI.skin.button)
-				{
-					normal =
-					{
-						textColor = _selectedAsset != null && _selectedAsset.Guid == asset.Guid ? Color.blue : Color.black
-					}
-				};
-
-				if (GUILayout.Button(asset.Name, style))
-				{
-					SelectAsset(asset);
-				}
-			}
-			EditorGUILayout.EndScrollView();
-		}
-
-		/// <summary>
-		/// Draws the asset detail section of the selected asset.
-		/// </summary>
-		private void DrawAssetDetailSection()
-		{
-			if (_selectedAsset == null)
-			{
-				return;
-			}
-
-			GUILayout.Label(string.Format("{0} Settings", _selectedAsset.Name), "PreToolbar");
-
-			// Name, type and price settings
-			GUILayout.Label("General:", EditorStyles.boldLabel);
-			_selectedAsset.Name = EditorGUILayout.TextField("Name", _selectedAsset.Name);
-			_selectedAsset.Type = (AssetType)EditorGUILayout.Popup("Type", (int)_selectedAsset.Type, new[]
-			{
-				AssetType.Deco.ToString(),
-				AssetType.Wall.ToString(),
-				AssetType.Trashbin.ToString(),
-				AssetType.Bench.ToString(),
-				AssetType.Fence.ToString(),
-				AssetType.Lamp.ToString(),
-				AssetType.Sign.ToString(),
-				AssetType.Tv.ToString(),
-				AssetType.FlatRide.ToString(),
-				AssetType.ImageSign.ToString(),
-				AssetType.Train.ToString()
-			});
-			_selectedAsset.Price = EditorGUILayout.FloatField("Price:", _selectedAsset.Price);
-
-			GUILayout.Label("Color settings", EditorStyles.boldLabel);
-			_selectedAsset.HasCustomColors = EditorGUILayout.Toggle("Has custom colors: ", _selectedAsset.HasCustomColors);
-			if (_selectedAsset.HasCustomColors)
-			{
-				_selectedAsset.ColorCount = Mathf.RoundToInt(EditorGUILayout.Slider("Color Count: ", _selectedAsset.ColorCount, 1, 4));
-				for (int i = 0; i < _selectedAsset.ColorCount; i++)
-				{
-					_selectedAsset.Colors[i] = EditorGUILayout.ColorField("Color " + (i + 1), _selectedAsset.Colors[i]);
-
-				}
-			}
-
-			GUILayout.Label("Light settings", EditorStyles.boldLabel);
-			_selectedAsset.LightsTurnOnAtNight = EditorGUILayout.Toggle("Turn on at night: ", _selectedAsset.LightsTurnOnAtNight);
-			if (_selectedAsset.LightsTurnOnAtNight && _selectedAsset.HasCustomColors) {
-				_selectedAsset.LightsUseCustomColors = EditorGUILayout.Toggle("Use custom colors: ", _selectedAsset.LightsUseCustomColors);
-				if (_selectedAsset.LightsUseCustomColors) {
-					_selectedAsset.LightsCustomColorSlot = (int)(CustomColorSlot)EditorGUILayout.EnumPopup("Custom color slot:", (CustomColorSlot)_selectedAsset.LightsCustomColorSlot);
-				}
-			}
-
-			// Type specific settings
-			switch (_selectedAsset.Type)
-			{
-				case AssetType.Wall:
-					DrawAssetWallDetailSection();
-					goto case AssetType.Deco;
-				case AssetType.Deco:
-					DrawAssetDecoDetailSection();
-					break;
-				case AssetType.Bench:
-					DrawAssetSeatingDetailSection();
-					GUILayout.Space(15);
-					DrawSeatsDetailSection(_selectedAsset.GameObject);
-					break;
-				case AssetType.Fence:
-					DrawAssetFenceDetailSection();
-					break;
-				case AssetType.Sign:
-					DrawAssetSignDetailSection();
-					break;
-				case AssetType.Tv:
-					DrawAssetTvDetailSection();
-					break;
-				case AssetType.ImageSign:
-					DrawAssetImageSignDetailSection();
-					goto case AssetType.Deco;
-				case AssetType.Train:
-					DrawAssetTrainDetailSection();
-					break;
-				case AssetType.FlatRide:
-					DrawAssetFlatRideDetailSection();
-					GUILayout.Space(15);
-					DrawBoundingBoxDetailSection();
-					GUILayout.Space(15);
-					DrawWaypointsDetailSection();
-					GUILayout.Space(15);
-					DrawSeatsDetailSection(_selectedAsset.GameObject);
-					break;
-			}
-
-			GUILayout.Space(20);
-
-			if (GUILayout.Button("Remove From Asset Pack"))
-			{
-				RemoveAsset(_selectedAsset);
-			}
-		}
-
-		private void DrawBoundingBoxDetailSection()
-		{
-			GUILayout.Label("Collisions", "PreToolbar");
-
-			if (_selectedAsset.BoundingBoxes.Count == 0)
-			{
-				EditorGUILayout.HelpBox("This ride has no collision yet", MessageType.Error);
-			}
-
-			Event e = Event.current;
-
-			for (int i = 0; i < _selectedAsset.BoundingBoxes.Count; i++)
-			{
-				EditorGUILayout.BeginHorizontal();
-				Color gui = GUI.color;
-				if (_selectedAsset.BoundingBoxes[i] == _selectedAsset.SelectedBoundingBox)
-				{
-					GUI.color = Color.red;
-				}
-
-				if (GUILayout.Button("BoundingBox" + (i + 1)))
-				{
-					if (_selectedAsset.SelectedBoundingBox == _selectedAsset.BoundingBoxes[i])
-					{
-						_selectedAsset.SelectedBoundingBox = null;
-						return;
-					}
-					_selectedAsset.SelectedBoundingBox = _selectedAsset.BoundingBoxes[i];
-				}
-				GUI.color = gui;
-				if (GUILayout.Button("Delete", GUILayout.ExpandWidth(false)))
-				{
-					_selectedAsset.BoundingBoxes.RemoveAt(i);
-				}
-				EditorGUILayout.EndHorizontal();
-			}
-
-			if (_selectedAsset.SelectedBoundingBox != null)
-			{
-				GUILayout.Label("Hold S - Snap to 0.25");
-			}
-
-			if (GUILayout.Button("Add bounding box"))
-			{
-				BoundingBox boundingBox = new BoundingBox();
-				boundingBox.Bounds = new Bounds(new Vector3(0, 0.5f, 0), Vector3.one);
-				_selectedAsset.BoundingBoxes.Add(boundingBox);
-			}
-		}
-
-		/// <summary>
-		/// Draws the asset deco detail section.
-		/// </summary>
-		private void DrawAssetDecoDetailSection()
-		{
-			// Category settings
-			GUILayout.Label("Category in the deco window:", EditorStyles.boldLabel);
-			_selectedAsset.Category = EditorGUILayout.TextField("Category:", _selectedAsset.Category);
-			_selectedAsset.SubCategory = EditorGUILayout.TextField("Sub category:", _selectedAsset.SubCategory);
-
-			// Placement settings
-			GUILayout.Label("Placement settings", EditorStyles.boldLabel);
-			if (_selectedAsset.Type != AssetType.Wall)
-			{
-				_selectedAsset.BuildOnGrid = EditorGUILayout.Toggle("Force build on grid: ", _selectedAsset.BuildOnGrid);
-				_selectedAsset.SnapCenter = EditorGUILayout.Toggle("Snaps to center: ", _selectedAsset.SnapCenter);
-				_selectedAsset.GridSubdivision = Mathf.RoundToInt(EditorGUILayout.Slider("Grid subdivision: ", _selectedAsset.GridSubdivision, 1, 9));
-			}
-			_selectedAsset.HeightDelta = Mathf.RoundToInt(EditorGUILayout.Slider("Height delta: ", _selectedAsset.HeightDelta, 0.05f, 1) * 200f) / 200f;
-			
-			GUILayout.Label("Size settings", EditorStyles.boldLabel);
-			_selectedAsset.IsResizable = EditorGUILayout.Toggle("Is resizable: ", _selectedAsset.IsResizable);
-
-			if (_selectedAsset.IsResizable)
-			{
-				_selectedAsset.MinSize = Mathf.RoundToInt(EditorGUILayout.Slider("Min size: ", _selectedAsset.MinSize, 0.1f, _selectedAsset.MaxSize) * 10f) / 10f;
-				_selectedAsset.MaxSize = Mathf.RoundToInt(EditorGUILayout.Slider("Max size: ", _selectedAsset.MaxSize, _selectedAsset.MinSize, 10) * 10f) / 10f;
-			}
-
-			GUILayout.Label("Visibility settings", EditorStyles.boldLabel);
-			_selectedAsset.CanSeeThrough = EditorGUILayout.Toggle("Can see through: ", _selectedAsset.CanSeeThrough);
-			_selectedAsset.BlocksRain = EditorGUILayout.Toggle("Blocks rain: ", _selectedAsset.BlocksRain);
-
-			if (_selectedAsset.GameObject != null && _selectedAsset.GameObject.GetComponent<Animator>() != null)
-			{
-				GUILayout.Label("Animation trigger", EditorStyles.boldLabel);
-				_selectedAsset.EffectsTriggerEnabled =
-					EditorGUILayout.Toggle("Animation can be triggered: ", _selectedAsset.EffectsTriggerEnabled);
-				if (_selectedAsset.EffectsTriggerEnabled)
-				{
-					_selectedAsset.EffectsTriggerCustomizableDuration =
-						EditorGUILayout.Toggle("Customizable duration: ", _selectedAsset.EffectsTriggerCustomizableDuration);
-				}
-			}
-		}
-
-
-		/// <summary>
-		/// Draws the asset flatride detail section.
-		/// </summary>
-		private void DrawAssetFlatRideDetailSection()
-		{
-			Animator animator = _selectedAsset.GameObject.GetComponent<Animator>();
-			if (animator == null) {
-				EditorGUILayout.HelpBox("This ride has no animator", MessageType.Error);
-			}
-			else if (animator.runtimeAnimatorController == null)
-			{
-				EditorGUILayout.HelpBox("This ride has no animator controller assigned (you can use Assets/Resources/Flat Rides/FlatRideAnimator.controller)", MessageType.Error);
-			}
-
-			//shows the rating of the ride
-			GUILayout.Label("Rating", EditorStyles.boldLabel);
-			_selectedAsset.Excitement = EditorGUILayout.Slider("Excitement", _selectedAsset.Excitement * 100, 0, 100) / 100f;
-			_selectedAsset.Intensity = EditorGUILayout.Slider("Intensity", _selectedAsset.Intensity * 100, 0, 100) / 100f;
-			_selectedAsset.Nausea = EditorGUILayout.Slider("Nausea", _selectedAsset.Nausea * 100, 0, 100) / 100f;
-
-			//the footprint that the ride covers
-			GUILayout.Label("Ride Footprint", EditorStyles.boldLabel);
-			_selectedAsset.FootprintX = EditorGUILayout.IntField("X", _selectedAsset.FootprintX);
-			_selectedAsset.FootprintZ = EditorGUILayout.IntField("Z", _selectedAsset.FootprintZ);
-
-			//category of the ride
-			GUILayout.Label("Ride settings", EditorStyles.boldLabel);
-			_selectedAsset.FlatRideCategory = AttractionType.CategoryTag[
-				EditorGUILayout.Popup("Category",
-					Array.IndexOf(AttractionType.CategoryTag, _selectedAsset.FlatRideCategory),
-					AttractionType.CategoryDisplayName)];
-
-
-			_selectedAsset.RainProtection = EditorGUILayout.Slider("Rain Protection", _selectedAsset.RainProtection * 100, 0, 100) / 100f;
-
-			EditorGUILayout.BeginHorizontal();
-			EditorGUILayout.PrefixLabel("Description");
-			_selectedAsset.Description = EditorGUILayout.TextArea(_selectedAsset.Description, GUILayout.Height(EditorGUIUtility.singleLineHeight * 3));
-			EditorGUILayout.EndHorizontal();
-		}
-
-		private void DrawWaypointsDetailSection()
-		{
-			//waypoint tool for NPC pathing
-			GUILayout.Label("Waypoints", "PreToolbar");
-
-			if (_selectedAsset.Waypoints.Count == 0)
-			{
-				EditorGUILayout.HelpBox("This ride has no waypoints yet", MessageType.Error);
-			}
-
-			_selectedAsset.EnableWaypointEditing =
-				GUILayout.Toggle(_selectedAsset.EnableWaypointEditing, "Enable Editing Waypoints", "Button");
-
-			if (_selectedAsset.EnableWaypointEditing)
-			{
-				GUILayout.Label("Ctrl - snap to plane height");
-				_selectedAsset.HelperPlaneY = EditorGUILayout.FloatField("Helper Plane Y", _selectedAsset.HelperPlaneY);
-
-				//generates an initial gride of waypoints around the outer squares
-				if (GUILayout.Button("Generate outer grid"))
-				{
-
-					float minX = -_selectedAsset.FootprintX / 2;
-					float maxX = _selectedAsset.FootprintX / 2;
-					float minZ = -_selectedAsset.FootprintZ / 2;
-					float maxZ = _selectedAsset.FootprintZ / 2;
-					for (int xi = 0; xi < Mathf.RoundToInt(maxX - minX); xi++)
-					{
-						for (int zi = 0; zi < Mathf.RoundToInt(maxZ - minZ); zi++)
-						{
-							float x = minX + xi;
-							float z = minZ + zi;
-							if (!(x == minX || x == maxX - 1) && !(z == minZ || z == maxZ - 1))
-							{
-								continue;
-							}
-
-							Waypoint newWaypoint = new Waypoint();
-							newWaypoint.Position = new Vector3(x + 0.5f, 0, z + 0.5f);
-							newWaypoint.IsOuter = true;
-							_selectedAsset.Waypoints.Add(newWaypoint);
-						}
-					}
-				}
-
-				//adds a waypoint at (0,0,0) relative to the unity object
-				if (GUILayout.Button("Add Waypoint"))
-				{
-					Waypoint.addWaypoint(_selectedAsset, _selectedAsset.GameObject.transform.position);
-				}
-
-				//clears all the waypoint
-				if (GUILayout.Button("Clear all"))
-				{
-					_selectedAsset.Waypoints.Clear();
-					_selectedAsset.SelectedWaypoint = null;
-				}
-
-				//provides a list of all the waypoints
-				for (int i = 0; i < _selectedAsset.Waypoints.Count; i++)
-				{
-					EditorGUILayout.BeginHorizontal();
-					GUILayout.Label("#" + i);
-					_selectedAsset.Waypoints[i].IsOuter =
-						GUILayout.Toggle(_selectedAsset.Waypoints[i].IsOuter, "IsOuter", "Button");
-					_selectedAsset.Waypoints[i].IsRabbitHoleGoal =
-						GUILayout.Toggle(_selectedAsset.Waypoints[i].IsRabbitHoleGoal, "IsRabbitHoleGoal", "Button");
-					if (GUILayout.Button("Delete"))
-					{
-						Waypoint.DeletePoint(_selectedAsset, _selectedAsset.SelectedWaypoint);
-					}
-
-					EditorGUILayout.EndHorizontal();
-
-					_selectedAsset.Waypoints[i].Position =
-						EditorGUILayout.Vector3Field("Position", _selectedAsset.Waypoints[i].Position);
-				}
-			}
-		}
-
-		private void DrawSeatsDetailSection(GameObject gameObject)
-		{
-			if (gameObject == null)
-			{
-				return;
-			}
-
-			GUILayout.Label("Seats", "PreToolbar");
-
-			var seats = gameObject.
-				GetComponentsInChildren<Transform>(true).
-				Where(transform => transform.name.StartsWith("Seat", true, CultureInfo.InvariantCulture));
-
-			if (seats.Count() == 0)
-			{
-				EditorGUILayout.HelpBox("There are no seats yet", MessageType.Warning);
-			}
-			else
-			{
-				EditorGUILayout.LabelField("Seats found", seats.Count().ToString());
-			}
-
-			foreach (Transform seat in seats)
-			{
-				if (GUILayout.Button(seat.name))
-				{
-					EditorGUIUtility.PingObject(seat.gameObject.GetInstanceID());
-					Selection.activeGameObject = seat.gameObject;
-				}
-			}
-
-			if (GUILayout.Button("Add seat"))
-			{
-				var seat = new GameObject("Seat");
-
-				seat.transform.SetParent(gameObject.transform);
-
-				seat.transform.localPosition = Vector3.zero;
-
-				Selection.activeGameObject = seat.gameObject;
-			}
-		}
-
-
-		/// <summary>
-		/// Draws the asset deco detail section.
-		/// </summary>
-		private void DrawAssetWallDetailSection()
-		{
-			// Category settings
-			GUILayout.Label("Wall settings:", EditorStyles.boldLabel);
-			_selectedAsset.Height = EditorGUILayout.FloatField("Height:", _selectedAsset.Height);
-			var north = EditorGUILayout.Toggle("Block North", Convert.ToBoolean(_selectedAsset.WallSettings & (int) WallBlock.Forward));
-			var east = EditorGUILayout.Toggle("Block East", Convert.ToBoolean(_selectedAsset.WallSettings & (int) WallBlock.Right));
-			var south = EditorGUILayout.Toggle("Block South", Convert.ToBoolean(_selectedAsset.WallSettings & (int) WallBlock.Back));
-			var west = EditorGUILayout.Toggle("Block West", Convert.ToBoolean(_selectedAsset.WallSettings & (int) WallBlock.Left));
-
-			var wallSettings = 0;
-
-			if (north)
-				wallSettings |= (int) WallBlock.Forward;
-			if (east)
-				wallSettings |= (int) WallBlock.Right;
-			if (south)
-				wallSettings |= (int) WallBlock.Back;
-			if (west)
-				wallSettings |= (int) WallBlock.Left;
-
-			_selectedAsset.WallSettings = wallSettings;
-		}
-
-		/// <summary>
-		/// Draws the asset seating detail section.
-		/// </summary>
-		private void DrawAssetSeatingDetailSection()
-		{
-			if (_selectedAsset.GameObject == null)
-			{
-				return;
-			}
-
-			// Bench settings
-			GUILayout.Label("Bench settings", EditorStyles.boldLabel);
-			_selectedAsset.HasBackRest = EditorGUILayout.Toggle("Has back rest: ", _selectedAsset.HasBackRest);
-		}
-		
-		/// <summary>
-		/// Draws the asset fence detail section.
-		/// </summary>
-		private void DrawAssetFenceDetailSection()
-		{
-			// Game object drop box
-			GUILayout.Label("Category in the deco window:", EditorStyles.boldLabel);
-			_selectedAsset.Category = EditorGUILayout.TextField("Category:", _selectedAsset.Category);
-			_selectedAsset.SubCategory = EditorGUILayout.TextField("Sub category:", _selectedAsset.SubCategory);
-
-			var post = EditorGUILayout.ObjectField("Post:", _selectedAsset.FencePost, typeof(GameObject), true) as GameObject;
-
-			if (post != _selectedAsset.FencePost)
-			{
-				post.transform.SetParent(_selectedAsset.GameObject.transform);
-				post.transform.localPosition = new Vector3(0.5f, 0, 0);
-
-				if (_selectedAsset.FencePost != null)
-				{
-					DestroyImmediate(_selectedAsset.FencePost);
-				}
-
-				_selectedAsset.FencePost = post;
-				post.name = "Post";
-			}
-			_selectedAsset.HasMidPost = EditorGUILayout.Toggle("Has mid post: ", _selectedAsset.HasMidPost);
-
-			DrawAssetWallDetailSection();
-		}
-		
-		/// <summary>
-		/// Draws the asset sign detail section.
-		/// </summary>
-		private void DrawAssetSignDetailSection()
-		{
-			GUILayout.Label("Sign settings:", EditorStyles.boldLabel);
-			var text = EditorGUILayout.ObjectField("Text object:", _selectedAsset.Text, typeof(GameObject), true) as GameObject;
-
-			if (text != _selectedAsset.Text)
-			{
-				_selectedAsset.Text = text;
-				text.name = "Text";
-			}
-		}
-		
-		/// <summary>
-		/// Draws the asset tv detail section.
-		/// </summary>
-		private void DrawAssetTvDetailSection()
-		{
-			GUILayout.Label("Tv settings:", EditorStyles.boldLabel);
-			var screen = EditorGUILayout.ObjectField("Screen object:", _selectedAsset.Screen, typeof(GameObject), true) as GameObject;
-
-			if (screen != _selectedAsset.Screen)
-			{
-				_selectedAsset.Screen = screen;
-				screen.name = "Screen";
-			}
-		}
-
-		/// <summary>
-		/// Draws the asset image sign detail section.
-		/// </summary>
-		private void DrawAssetImageSignDetailSection()
-		{
-			GUILayout.Label("Image Sign settings:", EditorStyles.boldLabel);
-			var sign = EditorGUILayout.ObjectField("Sign object:", _selectedAsset.Screen, typeof(GameObject), true) as GameObject;
-
-			if (sign != _selectedAsset.Screen)
-			{
-				_selectedAsset.Screen = sign;
-				sign.name = "Sign";
-			}
-
-			_selectedAsset.AspectRatio = (AspectRatio)EditorGUILayout.Popup("Aspect ratio", (int)_selectedAsset.AspectRatio, AspectRatioUtility.aspectRatioNames);
-		}
-
-		/// <summary>
-		/// Draws the asset image sign detail section.
-		/// </summary>
-		private void DrawAssetTrainDetailSection()
-		{
-			if (_selectedAsset.GameObject == null) {
-				return;
-			}
-
-			GUILayout.Label("Train settings:", EditorStyles.boldLabel);
-			
-			if (_selectedAsset.GameObject.transform.Find("backAxis") == null)
-			{
-				EditorGUILayout.HelpBox("There is no backAxis marker!", MessageType.Error);
-			}
-
-			int trackedRideNameIndex = EditorGUILayout.Popup("Ride", Array.IndexOf(trackedRideNames, _selectedAsset.TrackedRideName), trackedRideNames);
-			if (trackedRideNameIndex >= 0 && trackedRideNameIndex < trackedRideNames.Length) {
-				_selectedAsset.TrackedRideName = trackedRideNames[trackedRideNameIndex];
-			}
-
-			_selectedAsset.DefaultTrainLength = EditorGUILayout.IntSlider("Default train length: ", _selectedAsset.DefaultTrainLength, 1, 12);
-			_selectedAsset.MinTrainLength = EditorGUILayout.IntSlider("Minimum train length: ", _selectedAsset.MinTrainLength, 1, 12);
-			_selectedAsset.MaxTrainLength = EditorGUILayout.IntSlider("Maximum train length: ", _selectedAsset.MaxTrainLength, 1, 12);
-
-			GUILayout.Space(15);
-			
-			if (_selectedAsset.LeadCar == null)
-			{
-				CoasterCar car = new CoasterCar(_selectedAsset.Guid + ".leadCar");
-				car.GameObject = _selectedAsset.GameObject;
-				_selectedAsset.LeadCar = car;
-			}
-			GUILayout.Label("Lead Car:", EditorStyles.boldLabel);
-			DrawCarDetailSection(_selectedAsset.LeadCar);
-
-			GUILayout.Space(30);
-			
-			if (_selectedAsset.Car == null)
-			{
-				CoasterCar car = new CoasterCar(_selectedAsset.Guid + ".car");
-				_selectedAsset.Car = car;
-			}
-
-			if (_selectedAsset.Car.GameObject == _selectedAsset.LeadCar.GameObject) {
-				_selectedAsset.Car.GameObject = null;
-			}
-
-			GUILayout.Label("Normal Car:", EditorStyles.boldLabel);
-			DrawCarDetailSection(_selectedAsset.Car);
-
-			GUILayout.Space(30);
-			
-			if (_selectedAsset.RearCar == null)
-			{
-				CoasterCar car = new CoasterCar(_selectedAsset.Guid + ".rearCar");
-				_selectedAsset.RearCar = car;
-			}
-
-			if (_selectedAsset.RearCar.GameObject == _selectedAsset.LeadCar.GameObject || _selectedAsset.RearCar.GameObject == _selectedAsset.Car.GameObject) {
-				_selectedAsset.RearCar.GameObject = null;
-			}
-
-			GUILayout.Label("Rear Car:", EditorStyles.boldLabel);
-			DrawCarDetailSection(_selectedAsset.RearCar);
-		}
-
-		private void DrawCarDetailSection(CoasterCar car) {
-			var newAsset = EditorGUILayout.ObjectField("Drop to add:", car.GameObject, typeof(GameObject), true) as GameObject;
-			if (newAsset != null && newAsset != car.GameObject && newAsset.scene.name != null) // scene name is null for prefabs, yay for unity for checking it this way
-			{
-				car.GameObject = newAsset;
-			}
-
-			car.CoasterCarType = (CoasterCarType)EditorGUILayout.EnumPopup("Type:", car.CoasterCarType);
-			if (car.CoasterCarType == CoasterCarType.Spinning)
-			{
-				car.SpinFriction = EditorGUILayout.Slider("Spin friction:", car.SpinFriction, 0f, 1f);
-				car.SpinStrength = Mathf.RoundToInt(EditorGUILayout.Slider("Spin strength:", car.SpinStrength / 100f, 0f, 1f) * 100);
-				car.SpinSymmetrySides = EditorGUILayout.IntField("Spin symmetry sides:", car.SpinSymmetrySides);
-			}
-			else if (car.CoasterCarType == CoasterCarType.Swinging)
-			{
-				car.SwingFriction = EditorGUILayout.Slider("Swing friction:", car.SwingFriction, 0f, 1f);
-				car.SwingStrength = EditorGUILayout.Slider("Swing strength:", car.SwingStrength, 0f, 1f);
-				car.SwingMaxAngle = EditorGUILayout.FloatField("Max swing angle:", car.SwingMaxAngle);
-				car.SwingArmLength = EditorGUILayout.FloatField("Swing arm length:", car.SwingArmLength);
-			}
-
-			car.SeatWaypointOffset = EditorGUILayout.FloatField("Seat waypoint offset:", car.SeatWaypointOffset);
-			car.OffsetFront = EditorGUILayout.FloatField("Offset front:", car.OffsetFront);
-			car.OffsetBack = EditorGUILayout.FloatField("Offset back:", car.OffsetBack);
-			
-			DrawSeatsDetailSection(car.GameObject);
-
-			GUILayout.Space(15);
-
-			GUILayout.Label("Restraints", "PreToolbar");
-			for (int i = car.Restraints.Count - 1; i >= 0; i--)
-			{
-				CoasterRestraints restraints = car.Restraints[i];
-
-				EditorGUILayout.BeginHorizontal();
-				GUILayout.Label("#" + i);
-				if (GUILayout.Button("Delete"))
-				{
-					car.Restraints.RemoveAt(i);
-				}
-				EditorGUILayout.EndHorizontal();
-
-				restraints.TransformName = EditorGUILayout.TextField("Transform name", restraints.TransformName);
-				restraints.ClosedAngle = EditorGUILayout.FloatField("Closed angle (X-Axis)", restraints.ClosedAngle);
-			}
-
-			if (GUILayout.Button("Add"))
-			{
-				CoasterRestraints restraints = new CoasterRestraints();
-				restraints.TransformName = "restraint";
-				car.Restraints.Add(restraints);
-			}
-		}
-
-		/// <summary>
-		/// Selects an asset to draw its settings
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		private void SelectAsset(Asset asset)
-		{
-			_selectedAsset = asset;
-			
-			EditorGUIUtility.PingObject(_selectedAsset.GameObject.GetInstanceID());
-
-			Selection.activeGameObject = _selectedAsset.GameObject;
-		}
-
-		/// <summary>
-		/// Removes an asset.
-		/// </summary>
-		/// <param name="asset">The asset.</param>
-		private void RemoveAsset(Asset asset)
-		{
-			if (asset == _selectedAsset)
-			{
-				_selectedAsset = null;
-			}
-
-			ProjectManager.AssetPack.Remove(asset);
-		}
-	}
+        {
+            if (ProjectManager.AssetPack == null)
+            {
+                return;
+            }
+
+            if (_selectedAsset == null)
+            {
+                return;
+            }
+
+            foreach (var gizmoRenderer in _gizmoRenderers)
+            {
+                if (gizmoRenderer.CanRender(_selectedAsset))
+                {
+                    var renderer = gizmoRenderer as IHandleRenderer;
+                    if (renderer != null)
+                    {
+                        renderer.Handle(_selectedAsset);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Draws the asset pack settings section.
+        /// </summary>
+        private void DrawAssetPackSettingsSection()
+        {
+            GUILayout.Label("Asset Pack Settings", "PreToolbar");
+
+            ProjectManager.AssetPack.Name = EditorGUILayout.TextField("Name", ProjectManager.AssetPack.Name);
+            GUILayout.Label("Pack description", EditorStyles.boldLabel);
+            _descriptionTextScrollPosition = EditorGUILayout.BeginScrollView(_descriptionTextScrollPosition, GUILayout.Height(150));
+            ProjectManager.AssetPack.Description = EditorGUILayout.TextArea(ProjectManager.AssetPack.Description, GUILayout.ExpandHeight(true));
+            EditorGUILayout.EndScrollView();
+            ProjectManager.AssetPack.OrderPriority = EditorGUILayout.IntField("Load Order Priority", ProjectManager.AssetPack.OrderPriority);
+
+            GUILayout.Label("Assemblies", EditorStyles.boldLabel);
+            //adds a waypoint at (0,0,0) relative to the unity object
+            if (GUILayout.Button("Add Assembly"))
+            {
+                ProjectManager.AssetPack.Assemblies.Add("");
+            }
+
+            //provides a list of all the waypoints
+            for (int i = 0; i < ProjectManager.AssetPack.Assemblies.Count; i++)
+            {
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.Label("#" + i);
+
+                ProjectManager.AssetPack.Assemblies[i] = EditorGUILayout.TextField(ProjectManager.AssetPack.Assemblies[i]);
+
+                if (GUILayout.Button("Delete"))
+                {
+                    ProjectManager.AssetPack.Assemblies.RemoveAt(i);
+                    i--;
+                }
+
+                EditorGUILayout.EndHorizontal();
+            }
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.HelpBox("Stores your raw model files with the asset pack in an archive. Recommended: on", MessageType.Info);
+            ProjectManager.AssetPack.ArchiveAssets = EditorGUILayout.Toggle("Archive assets", ProjectManager.AssetPack.ArchiveAssets);
+
+            ProjectManager.AssetPack.VersionNumber = EditorGUILayout.TextField("Version number", ProjectManager.AssetPack.VersionNumber);
+
+            GUILayout.Space(10);
+
+            if (GUILayout.Button("Export Asset Pack"))
+            {
+                ProjectManager.Export(ProjectManager.AssetPack.ArchiveAssets);
+            }
+        }
+
+        /// <summary>
+        /// Draws the asset list section.
+        /// </summary>
+        private void DrawAssetListSection()
+        {
+            GUILayout.Label("Assets", "PreToolbar");
+
+            EditorGUILayout.HelpBox("Drag your GameObject to this field to start editing.", MessageType.Info);
+
+            // Game object drop box
+            var newAsset = EditorGUILayout.ObjectField("Drop to add:", null, typeof(GameObject), true) as GameObject;
+            if (newAsset != null && newAsset.scene.name != null) // scene name is null for prefabs, yay for unity for checking it this way
+            {
+                SelectAsset(ProjectManager.AssetPack.Add(newAsset));
+            }
+
+            // Asset list
+            _assetListScrollPos = EditorGUILayout.BeginScrollView(_assetListScrollPos, "GroupBox", GUILayout.Height(200));
+            foreach (var asset in ProjectManager.AssetPack.Assets)
+            {
+                // blue button for selected asset, black for non selected
+                var style = new GUIStyle(GUI.skin.button)
+                {
+                    normal =
+                    {
+                        textColor = _selectedAsset != null && _selectedAsset.Guid == asset.Guid ? Color.blue : Color.black
+                    }
+                };
+
+                if (GUILayout.Button(asset.Name, style))
+                {
+                    SelectAsset(asset);
+                }
+            }
+            EditorGUILayout.EndScrollView();
+        }
+
+        /// <summary>
+        /// Draws the asset detail section of the selected asset.
+        /// </summary>
+        private void DrawAssetDetailSection()
+        {
+            if (_selectedAsset == null)
+            {
+                return;
+            }
+
+            GUILayout.Label(string.Format("{0} Settings", _selectedAsset.Name), "PreToolbar");
+
+            // Name, type and price settings
+            GUILayout.Label("General:", EditorStyles.boldLabel);
+            _selectedAsset.Name = EditorGUILayout.TextField("Name", _selectedAsset.Name);
+            _selectedAsset.Type = (AssetType)EditorGUILayout.Popup("Type", (int)_selectedAsset.Type, new[]
+            {
+                AssetType.Deco.ToString(),
+                AssetType.Wall.ToString(),
+                AssetType.Trashbin.ToString(),
+                AssetType.Bench.ToString(),
+                AssetType.Fence.ToString(),
+                AssetType.Lamp.ToString(),
+                AssetType.Sign.ToString(),
+                AssetType.Tv.ToString(),
+                AssetType.FlatRide.ToString(),
+                AssetType.ImageSign.ToString(),
+                AssetType.Train.ToString()
+            });
+            _selectedAsset.Price = EditorGUILayout.FloatField("Price:", _selectedAsset.Price);
+
+            GUILayout.Label("Color settings", EditorStyles.boldLabel);
+            _selectedAsset.HasCustomColors = EditorGUILayout.Toggle("Has custom colors: ", _selectedAsset.HasCustomColors);
+            if (_selectedAsset.HasCustomColors)
+            {
+                _selectedAsset.ColorCount = Mathf.RoundToInt(EditorGUILayout.Slider("Color Count: ", _selectedAsset.ColorCount, 1, 4));
+                for (int i = 0; i < _selectedAsset.ColorCount; i++)
+                {
+                    _selectedAsset.Colors[i] = EditorGUILayout.ColorField("Color " + (i + 1), _selectedAsset.Colors[i]);
+
+                }
+            }
+
+            GUILayout.Label("Light settings", EditorStyles.boldLabel);
+            _selectedAsset.LightsTurnOnAtNight = EditorGUILayout.Toggle("Turn on at night: ", _selectedAsset.LightsTurnOnAtNight);
+            if (_selectedAsset.LightsTurnOnAtNight && _selectedAsset.HasCustomColors)
+            {
+                _selectedAsset.LightsUseCustomColors = EditorGUILayout.Toggle("Use custom colors: ", _selectedAsset.LightsUseCustomColors);
+                if (_selectedAsset.LightsUseCustomColors)
+                {
+                    _selectedAsset.LightsCustomColorSlot = (int)(CustomColorSlot)EditorGUILayout.EnumPopup("Custom color slot:", (CustomColorSlot)_selectedAsset.LightsCustomColorSlot);
+                }
+            }
+
+            // Type specific settings
+            switch (_selectedAsset.Type)
+            {
+                case AssetType.Wall:
+                    DrawAssetWallDetailSection();
+                    goto case AssetType.Deco;
+                case AssetType.Deco:
+                    DrawAssetDecoDetailSection();
+                    break;
+                case AssetType.Bench:
+                    DrawAssetSeatingDetailSection();
+                    GUILayout.Space(15);
+                    DrawSeatsDetailSection(_selectedAsset.GameObject);
+                    break;
+                case AssetType.Fence:
+                    DrawAssetFenceDetailSection();
+                    break;
+                case AssetType.Sign:
+                    DrawAssetSignDetailSection();
+                    break;
+                case AssetType.Tv:
+                    DrawAssetTvDetailSection();
+                    break;
+                case AssetType.ImageSign:
+                    DrawAssetImageSignDetailSection();
+                    goto case AssetType.Deco;
+                case AssetType.Train:
+                    DrawAssetTrainDetailSection();
+                    break;
+                case AssetType.FlatRide:
+                    DrawAssetFlatRideDetailSection();
+                    GUILayout.Space(15);
+                    DrawBoundingBoxDetailSection();
+                    GUILayout.Space(15);
+                    DrawWaypointsDetailSection();
+                    GUILayout.Space(15);
+                    DrawSeatsDetailSection(_selectedAsset.GameObject);
+                    break;
+            }
+
+            GUILayout.Space(20);
+
+            if (GUILayout.Button("Remove From Asset Pack"))
+            {
+                RemoveAsset(_selectedAsset);
+            }
+        }
+
+        private void DrawBoundingBoxDetailSection()
+        {
+            GUILayout.Label("Collisions", "PreToolbar");
+
+            if (_selectedAsset.BoundingBoxes.Count == 0)
+            {
+                EditorGUILayout.HelpBox("This ride has no collision yet", MessageType.Error);
+            }
+
+            Event e = Event.current;
+
+            for (int i = 0; i < _selectedAsset.BoundingBoxes.Count; i++)
+            {
+                EditorGUILayout.BeginHorizontal();
+                Color gui = GUI.color;
+                if (_selectedAsset.BoundingBoxes[i] == _selectedAsset.SelectedBoundingBox)
+                {
+                    GUI.color = Color.red;
+                }
+
+                if (GUILayout.Button("BoundingBox" + (i + 1)))
+                {
+                    if (_selectedAsset.SelectedBoundingBox == _selectedAsset.BoundingBoxes[i])
+                    {
+                        _selectedAsset.SelectedBoundingBox = null;
+                        return;
+                    }
+                    _selectedAsset.SelectedBoundingBox = _selectedAsset.BoundingBoxes[i];
+                }
+                GUI.color = gui;
+                if (GUILayout.Button("Delete", GUILayout.ExpandWidth(false)))
+                {
+                    _selectedAsset.BoundingBoxes.RemoveAt(i);
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+
+            if (_selectedAsset.SelectedBoundingBox != null)
+            {
+                GUILayout.Label("Hold S - Snap to 0.25");
+            }
+
+            if (GUILayout.Button("Add bounding box"))
+            {
+                BoundingBox boundingBox = new BoundingBox();
+                boundingBox.Bounds = new Bounds(new Vector3(0, 0.5f, 0), Vector3.one);
+                _selectedAsset.BoundingBoxes.Add(boundingBox);
+            }
+        }
+
+        /// <summary>
+        /// Draws the asset deco detail section.
+        /// </summary>
+        private void DrawAssetDecoDetailSection()
+        {
+            // Category settings
+            GUILayout.Label("Category in the deco window:", EditorStyles.boldLabel);
+            _selectedAsset.Category = EditorGUILayout.TextField("Category:", _selectedAsset.Category);
+            _selectedAsset.SubCategory = EditorGUILayout.TextField("Sub category:", _selectedAsset.SubCategory);
+
+            // Placement settings
+            GUILayout.Label("Placement settings", EditorStyles.boldLabel);
+            if (_selectedAsset.Type != AssetType.Wall)
+            {
+                _selectedAsset.BuildOnGrid = EditorGUILayout.Toggle("Force build on grid: ", _selectedAsset.BuildOnGrid);
+                _selectedAsset.SnapCenter = EditorGUILayout.Toggle("Snaps to center: ", _selectedAsset.SnapCenter);
+                _selectedAsset.GridSubdivision = Mathf.RoundToInt(EditorGUILayout.Slider("Grid subdivision: ", _selectedAsset.GridSubdivision, 1, 9));
+            }
+            _selectedAsset.HeightDelta = Mathf.RoundToInt(EditorGUILayout.Slider("Height delta: ", _selectedAsset.HeightDelta, 0.05f, 1) * 200f) / 200f;
+
+            GUILayout.Label("Size settings", EditorStyles.boldLabel);
+            _selectedAsset.IsResizable = EditorGUILayout.Toggle("Is resizable: ", _selectedAsset.IsResizable);
+
+            if (_selectedAsset.IsResizable)
+            {
+                _selectedAsset.MinSize = Mathf.RoundToInt(EditorGUILayout.Slider("Min size: ", _selectedAsset.MinSize, 0.1f, _selectedAsset.MaxSize) * 10f) / 10f;
+                _selectedAsset.MaxSize = Mathf.RoundToInt(EditorGUILayout.Slider("Max size: ", _selectedAsset.MaxSize, _selectedAsset.MinSize, 10) * 10f) / 10f;
+            }
+
+            GUILayout.Label("Visibility settings", EditorStyles.boldLabel);
+            _selectedAsset.CanSeeThrough = EditorGUILayout.Toggle("Can see through: ", _selectedAsset.CanSeeThrough);
+            _selectedAsset.BlocksRain = EditorGUILayout.Toggle("Blocks rain: ", _selectedAsset.BlocksRain);
+
+            if (_selectedAsset.GameObject != null && _selectedAsset.GameObject.GetComponent<Animator>() != null)
+            {
+                GUILayout.Label("Animation trigger", EditorStyles.boldLabel);
+                _selectedAsset.EffectsTriggerEnabled =
+                    EditorGUILayout.Toggle("Animation can be triggered: ", _selectedAsset.EffectsTriggerEnabled);
+                if (_selectedAsset.EffectsTriggerEnabled)
+                {
+                    _selectedAsset.EffectsTriggerCustomizableDuration =
+                        EditorGUILayout.Toggle("Customizable duration: ", _selectedAsset.EffectsTriggerCustomizableDuration);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Draws the asset flatride detail section.
+        /// </summary>
+        private void DrawAssetFlatRideDetailSection()
+        {
+            Animator animator = _selectedAsset.GameObject.GetComponent<Animator>();
+            if (animator == null)
+            {
+                EditorGUILayout.HelpBox("This ride has no animator", MessageType.Error);
+            }
+            else if (animator.runtimeAnimatorController == null)
+            {
+                EditorGUILayout.HelpBox("This ride has no animator controller assigned (you can use Assets/Resources/Flat Rides/FlatRideAnimator.controller)", MessageType.Error);
+            }
+
+            //shows the rating of the ride
+            GUILayout.Label("Rating", EditorStyles.boldLabel);
+            _selectedAsset.Excitement = EditorGUILayout.Slider("Excitement", _selectedAsset.Excitement * 100, 0, 100) / 100f;
+            _selectedAsset.Intensity = EditorGUILayout.Slider("Intensity", _selectedAsset.Intensity * 100, 0, 100) / 100f;
+            _selectedAsset.Nausea = EditorGUILayout.Slider("Nausea", _selectedAsset.Nausea * 100, 0, 100) / 100f;
+
+            //the footprint that the ride covers
+            GUILayout.Label("Ride Footprint", EditorStyles.boldLabel);
+            _selectedAsset.FootprintX = EditorGUILayout.IntField("X", _selectedAsset.FootprintX);
+            _selectedAsset.FootprintZ = EditorGUILayout.IntField("Z", _selectedAsset.FootprintZ);
+
+            //category of the ride
+            GUILayout.Label("Ride settings", EditorStyles.boldLabel);
+            _selectedAsset.FlatRideCategory = AttractionType.CategoryTag[
+                EditorGUILayout.Popup("Category",
+                    Array.IndexOf(AttractionType.CategoryTag, _selectedAsset.FlatRideCategory),
+                    AttractionType.CategoryDisplayName)];
+
+
+            _selectedAsset.RainProtection = EditorGUILayout.Slider("Rain Protection", _selectedAsset.RainProtection * 100, 0, 100) / 100f;
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.PrefixLabel("Description");
+            _selectedAsset.Description = EditorGUILayout.TextArea(_selectedAsset.Description, GUILayout.Height(EditorGUIUtility.singleLineHeight * 3));
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawWaypointsDetailSection()
+        {
+            //waypoint tool for NPC pathing
+            GUILayout.Label("Waypoints", "PreToolbar");
+
+            if (_selectedAsset.Waypoints.Count == 0)
+            {
+                EditorGUILayout.HelpBox("This ride has no waypoints yet", MessageType.Error);
+            }
+
+            _selectedAsset.EnableWaypointEditing =
+                GUILayout.Toggle(_selectedAsset.EnableWaypointEditing, "Enable Editing Waypoints", "Button");
+
+            if (_selectedAsset.EnableWaypointEditing)
+            {
+                GUILayout.Label("Ctrl - snap to plane height");
+                _selectedAsset.HelperPlaneY = EditorGUILayout.FloatField("Helper Plane Y", _selectedAsset.HelperPlaneY);
+
+                //generates an initial gride of waypoints around the outer squares
+                if (GUILayout.Button("Generate outer grid"))
+                {
+
+                    float minX = -_selectedAsset.FootprintX / 2;
+                    float maxX = _selectedAsset.FootprintX / 2;
+                    float minZ = -_selectedAsset.FootprintZ / 2;
+                    float maxZ = _selectedAsset.FootprintZ / 2;
+                    for (int xi = 0; xi < Mathf.RoundToInt(maxX - minX); xi++)
+                    {
+                        for (int zi = 0; zi < Mathf.RoundToInt(maxZ - minZ); zi++)
+                        {
+                            float x = minX + xi;
+                            float z = minZ + zi;
+                            if (!(x == minX || x == maxX - 1) && !(z == minZ || z == maxZ - 1))
+                            {
+                                continue;
+                            }
+
+                            Waypoint newWaypoint = new Waypoint();
+                            newWaypoint.Position = new Vector3(x + 0.5f, 0, z + 0.5f);
+                            newWaypoint.IsOuter = true;
+                            _selectedAsset.Waypoints.Add(newWaypoint);
+                        }
+                    }
+                }
+
+                //adds a waypoint at (0,0,0) relative to the unity object
+                if (GUILayout.Button("Add Waypoint"))
+                {
+                    Waypoint.addWaypoint(_selectedAsset, _selectedAsset.GameObject.transform.position);
+                }
+
+                //clears all the waypoint
+                if (GUILayout.Button("Clear all"))
+                {
+                    _selectedAsset.Waypoints.Clear();
+                    _selectedAsset.SelectedWaypoint = null;
+                }
+
+                //provides a list of all the waypoints
+                for (int i = 0; i < _selectedAsset.Waypoints.Count; i++)
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    GUILayout.Label("#" + i);
+                    _selectedAsset.Waypoints[i].IsOuter =
+                        GUILayout.Toggle(_selectedAsset.Waypoints[i].IsOuter, "IsOuter", "Button");
+                    _selectedAsset.Waypoints[i].IsRabbitHoleGoal =
+                        GUILayout.Toggle(_selectedAsset.Waypoints[i].IsRabbitHoleGoal, "IsRabbitHoleGoal", "Button");
+                    if (GUILayout.Button("Delete"))
+                    {
+                        Waypoint.DeletePoint(_selectedAsset, _selectedAsset.SelectedWaypoint);
+                    }
+
+                    EditorGUILayout.EndHorizontal();
+
+                    _selectedAsset.Waypoints[i].Position =
+                        EditorGUILayout.Vector3Field("Position", _selectedAsset.Waypoints[i].Position);
+                }
+            }
+        }
+
+        private void DrawSeatsDetailSection(GameObject gameObject)
+        {
+            if (gameObject == null)
+            {
+                return;
+            }
+
+            GUILayout.Label("Seats", "PreToolbar");
+
+            var seats = gameObject.
+                GetComponentsInChildren<Transform>(true).
+                Where(transform => transform.name.StartsWith("Seat", true, CultureInfo.InvariantCulture));
+
+            if (seats.Count() == 0)
+            {
+                EditorGUILayout.HelpBox("There are no seats yet", MessageType.Warning);
+            }
+            else
+            {
+                EditorGUILayout.LabelField("Seats found", seats.Count().ToString());
+            }
+
+            foreach (Transform seat in seats)
+            {
+                if (GUILayout.Button(seat.name))
+                {
+                    EditorGUIUtility.PingObject(seat.gameObject.GetInstanceID());
+                    Selection.activeGameObject = seat.gameObject;
+                }
+            }
+
+            if (GUILayout.Button("Add seat"))
+            {
+                var seat = new GameObject("Seat");
+
+                seat.transform.SetParent(gameObject.transform);
+
+                seat.transform.localPosition = Vector3.zero;
+
+                Selection.activeGameObject = seat.gameObject;
+            }
+        }
+
+
+        /// <summary>
+        /// Draws the asset deco detail section.
+        /// </summary>
+        private void DrawAssetWallDetailSection()
+        {
+            // Category settings
+            GUILayout.Label("Wall settings:", EditorStyles.boldLabel);
+            _selectedAsset.Height = EditorGUILayout.FloatField("Height:", _selectedAsset.Height);
+            var north = EditorGUILayout.Toggle("Block North", Convert.ToBoolean(_selectedAsset.WallSettings & (int)WallBlock.Forward));
+            var east = EditorGUILayout.Toggle("Block East", Convert.ToBoolean(_selectedAsset.WallSettings & (int)WallBlock.Right));
+            var south = EditorGUILayout.Toggle("Block South", Convert.ToBoolean(_selectedAsset.WallSettings & (int)WallBlock.Back));
+            var west = EditorGUILayout.Toggle("Block West", Convert.ToBoolean(_selectedAsset.WallSettings & (int)WallBlock.Left));
+
+            var wallSettings = 0;
+
+            if (north)
+                wallSettings |= (int)WallBlock.Forward;
+            if (east)
+                wallSettings |= (int)WallBlock.Right;
+            if (south)
+                wallSettings |= (int)WallBlock.Back;
+            if (west)
+                wallSettings |= (int)WallBlock.Left;
+
+            _selectedAsset.WallSettings = wallSettings;
+        }
+
+        /// <summary>
+        /// Draws the asset seating detail section.
+        /// </summary>
+        private void DrawAssetSeatingDetailSection()
+        {
+            if (_selectedAsset.GameObject == null)
+            {
+                return;
+            }
+
+            // Bench settings
+            GUILayout.Label("Bench settings", EditorStyles.boldLabel);
+            _selectedAsset.HasBackRest = EditorGUILayout.Toggle("Has back rest: ", _selectedAsset.HasBackRest);
+        }
+
+        /// <summary>
+        /// Draws the asset fence detail section.
+        /// </summary>
+        private void DrawAssetFenceDetailSection()
+        {
+            // Game object drop box
+            GUILayout.Label("Category in the deco window:", EditorStyles.boldLabel);
+            _selectedAsset.Category = EditorGUILayout.TextField("Category:", _selectedAsset.Category);
+            _selectedAsset.SubCategory = EditorGUILayout.TextField("Sub category:", _selectedAsset.SubCategory);
+
+            var post = EditorGUILayout.ObjectField("Post:", _selectedAsset.FencePost, typeof(GameObject), true) as GameObject;
+
+            if (post != _selectedAsset.FencePost)
+            {
+                post.transform.SetParent(_selectedAsset.GameObject.transform);
+                post.transform.localPosition = new Vector3(0.5f, 0, 0);
+
+                if (_selectedAsset.FencePost != null)
+                {
+                    DestroyImmediate(_selectedAsset.FencePost);
+                }
+
+                _selectedAsset.FencePost = post;
+                post.name = "Post";
+            }
+            _selectedAsset.HasMidPost = EditorGUILayout.Toggle("Has mid post: ", _selectedAsset.HasMidPost);
+
+            DrawAssetWallDetailSection();
+        }
+
+        /// <summary>
+        /// Draws the asset sign detail section.
+        /// </summary>
+        private void DrawAssetSignDetailSection()
+        {
+            GUILayout.Label("Sign settings:", EditorStyles.boldLabel);
+            var text = EditorGUILayout.ObjectField("Text object:", _selectedAsset.Text, typeof(GameObject), true) as GameObject;
+
+            if (text != _selectedAsset.Text)
+            {
+                _selectedAsset.Text = text;
+                text.name = "Text";
+            }
+        }
+
+        /// <summary>
+        /// Draws the asset tv detail section.
+        /// </summary>
+        private void DrawAssetTvDetailSection()
+        {
+            GUILayout.Label("Tv settings:", EditorStyles.boldLabel);
+            var screen = EditorGUILayout.ObjectField("Screen object:", _selectedAsset.Screen, typeof(GameObject), true) as GameObject;
+
+            if (screen != _selectedAsset.Screen)
+            {
+                _selectedAsset.Screen = screen;
+                screen.name = "Screen";
+            }
+        }
+
+        /// <summary>
+        /// Draws the asset image sign detail section.
+        /// </summary>
+        private void DrawAssetImageSignDetailSection()
+        {
+            GUILayout.Label("Image Sign settings:", EditorStyles.boldLabel);
+            var sign = EditorGUILayout.ObjectField("Sign object:", _selectedAsset.Screen, typeof(GameObject), true) as GameObject;
+
+            if (sign != _selectedAsset.Screen)
+            {
+                _selectedAsset.Screen = sign;
+                sign.name = "Sign";
+            }
+
+            _selectedAsset.AspectRatio = (AspectRatio)EditorGUILayout.Popup("Aspect ratio", (int)_selectedAsset.AspectRatio, AspectRatioUtility.aspectRatioNames);
+        }
+
+        /// <summary>
+        /// Draws the asset image sign detail section.
+        /// </summary>
+        private void DrawAssetTrainDetailSection()
+        {
+            if (_selectedAsset.GameObject == null)
+            {
+                return;
+            }
+
+            GUILayout.Label("Train settings:", EditorStyles.boldLabel);
+
+            if (_selectedAsset.GameObject.transform.Find("backAxis") == null)
+            {
+                EditorGUILayout.HelpBox("There is no backAxis marker!", MessageType.Error);
+            }
+
+            int trackedRideNameIndex = EditorGUILayout.Popup("Ride", Array.IndexOf(trackedRideNames, _selectedAsset.TrackedRideName), trackedRideNames);
+            if (trackedRideNameIndex >= 0 && trackedRideNameIndex < trackedRideNames.Length)
+            {
+                _selectedAsset.TrackedRideName = trackedRideNames[trackedRideNameIndex];
+            }
+
+            _selectedAsset.DefaultTrainLength = EditorGUILayout.IntSlider("Default train length: ", _selectedAsset.DefaultTrainLength, 1, 12);
+            _selectedAsset.MinTrainLength = EditorGUILayout.IntSlider("Minimum train length: ", _selectedAsset.MinTrainLength, 1, 12);
+            _selectedAsset.MaxTrainLength = EditorGUILayout.IntSlider("Maximum train length: ", _selectedAsset.MaxTrainLength, 1, 12);
+
+            GUILayout.Space(15);
+
+            if (_selectedAsset.LeadCar == null)
+            {
+                CoasterCar car = new CoasterCar(_selectedAsset.Guid + ".leadCar");
+                car.GameObject = _selectedAsset.GameObject;
+                _selectedAsset.LeadCar = car;
+            }
+            GUILayout.Label("Lead Car:", EditorStyles.boldLabel);
+            DrawCarDetailSection(_selectedAsset.LeadCar);
+
+            GUILayout.Space(30);
+
+            if (_selectedAsset.Car == null)
+            {
+                CoasterCar car = new CoasterCar(_selectedAsset.Guid + ".car");
+                _selectedAsset.Car = car;
+            }
+
+            if (_selectedAsset.Car.GameObject == _selectedAsset.LeadCar.GameObject)
+            {
+                _selectedAsset.Car.GameObject = null;
+            }
+
+            GUILayout.Label("Normal Car:", EditorStyles.boldLabel);
+            DrawCarDetailSection(_selectedAsset.Car);
+
+            GUILayout.Space(30);
+
+            if (_selectedAsset.RearCar == null)
+            {
+                CoasterCar car = new CoasterCar(_selectedAsset.Guid + ".rearCar");
+                _selectedAsset.RearCar = car;
+            }
+
+            if (_selectedAsset.RearCar.GameObject == _selectedAsset.LeadCar.GameObject || _selectedAsset.RearCar.GameObject == _selectedAsset.Car.GameObject)
+            {
+                _selectedAsset.RearCar.GameObject = null;
+            }
+
+            GUILayout.Label("Rear Car:", EditorStyles.boldLabel);
+            DrawCarDetailSection(_selectedAsset.RearCar);
+        }
+
+        private void DrawCarDetailSection(CoasterCar car)
+        {
+            var newAsset = EditorGUILayout.ObjectField("Drop to add:", car.GameObject, typeof(GameObject), true) as GameObject;
+            if (newAsset != null && newAsset != car.GameObject && newAsset.scene.name != null) // scene name is null for prefabs, yay for unity for checking it this way
+            {
+                car.GameObject = newAsset;
+            }
+
+            car.CoasterCarType = (CoasterCarType)EditorGUILayout.EnumPopup("Type:", car.CoasterCarType);
+            if (car.CoasterCarType == CoasterCarType.Spinning)
+            {
+                car.SpinFriction = EditorGUILayout.Slider("Spin friction:", car.SpinFriction, 0f, 1f);
+                car.SpinStrength = Mathf.RoundToInt(EditorGUILayout.Slider("Spin strength:", car.SpinStrength / 100f, 0f, 1f) * 100);
+                car.SpinSymmetrySides = EditorGUILayout.IntField("Spin symmetry sides:", car.SpinSymmetrySides);
+            }
+            else if (car.CoasterCarType == CoasterCarType.Swinging)
+            {
+                car.SwingFriction = EditorGUILayout.Slider("Swing friction:", car.SwingFriction, 0f, 1f);
+                car.SwingStrength = EditorGUILayout.Slider("Swing strength:", car.SwingStrength, 0f, 1f);
+                car.SwingMaxAngle = EditorGUILayout.FloatField("Max swing angle:", car.SwingMaxAngle);
+                car.SwingArmLength = EditorGUILayout.FloatField("Swing arm length:", car.SwingArmLength);
+            }
+
+            car.SeatWaypointOffset = EditorGUILayout.FloatField("Seat waypoint offset:", car.SeatWaypointOffset);
+            car.OffsetFront = EditorGUILayout.FloatField("Offset front:", car.OffsetFront);
+            car.OffsetBack = EditorGUILayout.FloatField("Offset back:", car.OffsetBack);
+
+            DrawSeatsDetailSection(car.GameObject);
+
+            GUILayout.Space(15);
+
+            GUILayout.Label("Restraints", "PreToolbar");
+            for (int i = car.Restraints.Count - 1; i >= 0; i--)
+            {
+                CoasterRestraints restraints = car.Restraints[i];
+
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.Label("#" + i);
+                if (GUILayout.Button("Delete"))
+                {
+                    car.Restraints.RemoveAt(i);
+                }
+                EditorGUILayout.EndHorizontal();
+
+                restraints.TransformName = EditorGUILayout.TextField("Transform name", restraints.TransformName);
+                restraints.ClosedAngle = EditorGUILayout.FloatField("Closed angle (X-Axis)", restraints.ClosedAngle);
+            }
+
+            if (GUILayout.Button("Add"))
+            {
+                CoasterRestraints restraints = new CoasterRestraints();
+                restraints.TransformName = "restraint";
+                car.Restraints.Add(restraints);
+            }
+        }
+
+        /// <summary>
+        /// Selects an asset to draw its settings
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        private void SelectAsset(Asset asset)
+        {
+            _selectedAsset = asset;
+
+            EditorGUIUtility.PingObject(_selectedAsset.GameObject.GetInstanceID());
+
+            Selection.activeGameObject = _selectedAsset.GameObject;
+        }
+
+        /// <summary>
+        /// Removes an asset.
+        /// </summary>
+        /// <param name="asset">The asset.</param>
+        private void RemoveAsset(Asset asset)
+        {
+            if (asset == _selectedAsset)
+            {
+                _selectedAsset = null;
+            }
+
+            ProjectManager.AssetPack.Remove(asset);
+        }
+    }
 
 }

--- a/Assets/Editor/UI/AutoSave.cs
+++ b/Assets/Editor/UI/AutoSave.cs
@@ -4,7 +4,7 @@ namespace ParkitectAssetEditor.Assets.Editor.UI
 {
     public class AssetProcessor : SaveAssetsProcessor
     {
-        static string[] OnWillSaveAssets(string[] paths)
+        private static string[] OnWillSaveAssets(string[] paths)
         {
             ProjectManager.Save();
 

--- a/Assets/Editor/UI/AutoSave.cs
+++ b/Assets/Editor/UI/AutoSave.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEditor;
+﻿using UnityEditor;
 
 namespace ParkitectAssetEditor.Assets.Editor.UI
 {

--- a/Assets/Editor/UI/NewProjectWindow.cs
+++ b/Assets/Editor/UI/NewProjectWindow.cs
@@ -30,7 +30,7 @@ namespace ParkitectAssetEditor.UI
             window.position = new Rect(Screen.width / 2, Screen.height / 2, 300, 50);
             window.ShowUtility();
         }
-        
+
         public void OnGUI()
         {
             _name = EditorGUILayout.TextField("Project Name", _name);

--- a/Assets/Editor/Utility/AssetImporter.cs
+++ b/Assets/Editor/Utility/AssetImporter.cs
@@ -2,15 +2,15 @@
 
 namespace ParkitectAssetEditor.Utility
 {
-	internal sealed class AssetImporter : AssetPostprocessor
-	{
-		private void OnPreprocessModel()
-		{
-			var importer = assetImporter as ModelImporter;
-			
-			importer.materialName = ModelImporterMaterialName.BasedOnMaterialName;
-			importer.materialSearch = ModelImporterMaterialSearch.Everywhere;
-			importer.isReadable = true;
-		}
-	}
+    internal sealed class AssetImporter : AssetPostprocessor
+    {
+        private void OnPreprocessModel()
+        {
+            var importer = assetImporter as ModelImporter;
+
+            importer.materialName = ModelImporterMaterialName.BasedOnMaterialName;
+            importer.materialSearch = ModelImporterMaterialSearch.Everywhere;
+            importer.isReadable = true;
+        }
+    }
 }

--- a/Assets/Editor/Utility/BoundingBox.cs
+++ b/Assets/Editor/Utility/BoundingBox.cs
@@ -8,18 +8,18 @@ namespace ParkitectAssetEditor.Utility
         [JsonIgnore]
         public Bounds Bounds;
 
-        
+
         [JsonProperty("BoundsMin")]
         public float[] SerializedMin
         {
-            get { return new float[3] {Bounds.min.x, Bounds.min.y, Bounds.min.z}; }
+            get { return new float[3] { Bounds.min.x, Bounds.min.y, Bounds.min.z }; }
             set { Bounds.min = new Vector3(value[0], value[1], value[2]); }
         }
-        
+
         [JsonProperty("BoundsMax")]
         public float[] SerializedMax
         {
-            get { return new float[3] {Bounds.max.x, Bounds.max.y, Bounds.max.z}; }
+            get { return new float[3] { Bounds.max.x, Bounds.max.y, Bounds.max.z }; }
             set { Bounds.max = new Vector3(value[0], value[1], value[2]); }
         }
     }

--- a/Assets/Editor/Utility/Utility.cs
+++ b/Assets/Editor/Utility/Utility.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/Editor/Utility/Utility.cs
+++ b/Assets/Editor/Utility/Utility.cs
@@ -3,15 +3,16 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace ParkitectAssetEditor.Utility {
+namespace ParkitectAssetEditor.Utility
+{
     /// <summary>
     /// Helper methods/properties
     /// </summary>
     public static class Utility
     {
-		/// <summary>
-		/// Gets the path to the parkitect mod folder.
-		/// </summary>
+        /// <summary>
+        /// Gets the path to the parkitect mod folder.
+        /// </summary>
         public static string ParkitectModPath
         {
             get
@@ -19,39 +20,40 @@ namespace ParkitectAssetEditor.Utility {
 #if UNITY_STANDALONE_OSX
 				return System.IO.Path.GetFullPath(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "/../Library/Application Support/Parkitect/", "Mods"));
 #elif UNITY_STANDALONE_WIN
-				return System.IO.Path.GetFullPath(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/Parkitect/", "Mods"));
+                return System.IO.Path.GetFullPath(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/Parkitect/", "Mods"));
 #else
 				return System.IO.Path.GetFullPath(System.IO.Path.Combine(Application.dataPath + "/..", "Mods"));
 #endif
             }
         }
 
-        
-		private static Mesh npcMesh;
-		private static Material sceneViewMaterial;
 
-        public static void renderSeatGizmo(GameObject gameObject) {
+        private static Mesh npcMesh;
+        private static Material sceneViewMaterial;
+
+        public static void renderSeatGizmo(GameObject gameObject)
+        {
             if (npcMesh == null)
-			{
-				npcMesh = Resources.Load<Mesh>("Reference Objects/reference_guest_sitting");
-			}
+            {
+                npcMesh = Resources.Load<Mesh>("Reference Objects/reference_guest_sitting");
+            }
 
-			if (sceneViewMaterial == null)
-			{
-				sceneViewMaterial = (Material)AssetDatabase.LoadAssetAtPath("Assets/Editor/SceneViewGhostMaterial.mat", typeof(Material));
-			}
+            if (sceneViewMaterial == null)
+            {
+                sceneViewMaterial = (Material)AssetDatabase.LoadAssetAtPath("Assets/Editor/SceneViewGhostMaterial.mat", typeof(Material));
+            }
 
-			var seats = gameObject.
-				GetComponentsInChildren<Transform>(true).
-				Where(transform => transform.name.StartsWith("Seat", true, System.Globalization.CultureInfo.InvariantCulture));
+            var seats = gameObject.
+                GetComponentsInChildren<Transform>(true).
+                Where(transform => transform.name.StartsWith("Seat", true, System.Globalization.CultureInfo.InvariantCulture));
 
-			foreach (var seat in seats)
-			{
-				sceneViewMaterial.SetPass(0);
-				Graphics.DrawMeshNow(npcMesh, seat.position, seat.rotation); 
-				sceneViewMaterial.SetPass(1);
-				Graphics.DrawMeshNow(npcMesh, seat.position, seat.rotation);
-			}
+            foreach (var seat in seats)
+            {
+                sceneViewMaterial.SetPass(0);
+                Graphics.DrawMeshNow(npcMesh, seat.position, seat.rotation);
+                sceneViewMaterial.SetPass(1);
+                Graphics.DrawMeshNow(npcMesh, seat.position, seat.rotation);
+            }
         }
     }
 }

--- a/Assets/Editor/WallBlock.cs
+++ b/Assets/Editor/WallBlock.cs
@@ -5,9 +5,9 @@
     /// </summary>
     enum WallBlock
     {
-	    Back = 1 << 0,
-	    Right = 1 << 1,
-	    Forward = 1 << 2,
-	    Left = 1 << 3
-	}
+        Back = 1 << 0,
+        Right = 1 << 1,
+        Forward = 1 << 2,
+        Left = 1 << 3
+    }
 }

--- a/Assets/Editor/Waypoint.cs
+++ b/Assets/Editor/Waypoint.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using UnityEditor;
 using UnityEngine;
 
 namespace ParkitectAssetEditor

--- a/Assets/Editor/Waypoint.cs
+++ b/Assets/Editor/Waypoint.cs
@@ -6,7 +6,7 @@ namespace ParkitectAssetEditor
 {
     public class Waypoint
     {
-        
+
         [JsonIgnore]
         public Vector3 Position;
 
@@ -20,13 +20,13 @@ namespace ParkitectAssetEditor
         [JsonProperty("Position")]
         public float[] SerializedPosition
         {
-            get { return new float[3] {Position.x, Position.y, Position.z}; }
+            get { return new float[3] { Position.x, Position.y, Position.z }; }
             set { Position = new Vector3(value[0], value[1], value[2]); }
         }
 
-        public static void DeletePoint(Asset asset,Waypoint SelectedWaypoint)
+        public static void DeletePoint(Asset asset, Waypoint SelectedWaypoint)
         {
-            int selectedWaypointIndex = asset.Waypoints.FindIndex(delegate(Waypoint wp) { return wp == SelectedWaypoint; });
+            int selectedWaypointIndex = asset.Waypoints.FindIndex(delegate (Waypoint wp) { return wp == SelectedWaypoint; });
             foreach (Waypoint waypoint in asset.Waypoints)
             {
                 waypoint.ConnectedTo.Remove(selectedWaypointIndex);
@@ -34,7 +34,7 @@ namespace ParkitectAssetEditor
 
             asset.Waypoints.Remove(SelectedWaypoint);
 
-            foreach (Waypoint waypoint in  asset.Waypoints)
+            foreach (Waypoint waypoint in asset.Waypoints)
             {
                 for (int i = 0; i < waypoint.ConnectedTo.Count; i++)
                 {
@@ -47,8 +47,8 @@ namespace ParkitectAssetEditor
 
             asset.SelectedWaypoint = null;
         }
-        
-        public static Waypoint addWaypoint(Asset asset,Vector3 position)
+
+        public static Waypoint addWaypoint(Asset asset, Vector3 position)
         {
             Waypoint waypoint = new Waypoint();
             waypoint.Position = asset.GameObject.transform.InverseTransformPoint(position);

--- a/Assets/GameObjectHashMap.cs
+++ b/Assets/GameObjectHashMap.cs
@@ -43,7 +43,7 @@ public class GameObjectHashMap : MonoBehaviour
 
     public List<GameObject> GameObjects = new List<GameObject>(10);
 
-    void Awake()
+    private void Awake()
     {
         _instance = this;
     }


### PR DESCRIPTION
Across the project, there has been a bit of a mix of formatting styles, which this PR is trying to fix. Most of the operations have been performed by Visual Studio/Roslyn/Analyzers and therefore do not have any functional impact.

The following things were changed:

- Tabs and spaces for indentation were unified to use the C# common style of 4 spaces. There were files that were indented with tabs, some with spaces, and some with a wild mix of both. They've all been unified to use spaces instead.
- Empty lines are fully empty, with no indentation.
- Removed trailing whitespaces.
- Opening curly brackets (`{`) belong on a new line.
- Spaces between curly brackets and values (e.g. `{ Foo = bar }`)
- No spaces between minuses and numbers
- No spaces between C-style casts (`(int)foo`)

It looks like it's a rather big PR, but that's just because it unifies the indentation. Whether it switches to tabs or spaces did not seem to make a huge difference from a small trial I ran, as the usage was about even (and mixed lines had to be converted to one or the other anyway).

In order to unify the coding style for the future, I've added an `.editorconfig`, which _should_ be supported by most IDEs. This should help keeping the style consistent in the future.